### PR TITLE
mkdir: effective options -v and -p

### DIFF
--- a/toys/posix/mkdir.c
+++ b/toys/posix/mkdir.c
@@ -30,13 +30,16 @@ void mkdir_main(void)
 {
   char **s;
   mode_t mode = (0777&~toys.old_umask);
-
+  int mkflag;
 
   if (TT.arg_mode) mode = string_to_mode(TT.arg_mode, 0777);
 
-  // Note, -p and -v flags line up with mkpathat() flags
+  // Note, -p and -v flags AREN'T line up with mkpathat() flags
 
+  mkflag = 1;
+  if (toys.optflags & FLAG_p) mkflag |= 2;
+  if (toys.optflags & FLAG_v) mkflag |= 4;
   for (s=toys.optargs; *s; s++)
-    if (mkpathat(AT_FDCWD, *s, mode, toys.optflags|1))
+    if (mkpathat(AT_FDCWD, *s, mode, mkflags))
       perror_msg("'%s'", *s);
 }


### PR DESCRIPTION
Despite the previous comment stating that options
of mkpathat are line up with -p and -v (or conversly),
options -p and -v wasn't effective for command 'mkdir'.

This patch make it effective.

Change-Id: I8d908eb852190b83d245e51e6d3f3ebdbfba7665
Signed-off-by: José Bollo <jose.bollo@open.eurogiciel.org>