### PR TITLE
Fix a few clang warnings

### DIFF
--- a/lib/args.c
+++ b/lib/args.c
@@ -251,7 +251,7 @@ void parse_optflaglist(struct getoptflagstate *gof)
 
   if (!*options) gof->stopearly++;
   while (*options) {
-    char *temp;
+    char *temp = "";
 
     // Option groups come after all options are defined
     if (*options == '[') break;

--- a/lib/lsm.h
+++ b/lib/lsm.h
@@ -52,7 +52,7 @@ static inline char *lsm_name(void)
 static inline char *lsm_context(void)
 {
   int ok = 0;
-  char *result;
+  char *result = "";
 
   if (CFG_TOYBOX_SMACK) ok = smack_new_label_from_self(&result) > 0;
   else ok = getcon(&result) == 0;

--- a/toys/pending/ip.c
+++ b/toys/pending/ip.c
@@ -1402,7 +1402,7 @@ static int ipaddr_print( struct linkdata *link, int flag_l)
         }
 
         for (; NLMSG_OK(addr_ptr, len); addr_ptr = NLMSG_NEXT(addr_ptr, len)) {
-          if ((addr_ptr->nlmsg_type == RTM_NEWADDR))
+          if (addr_ptr->nlmsg_type == RTM_NEWADDR)
             print_addrinfo(addr_ptr, flag_l);
           if ((addr_ptr->nlmsg_type == NLMSG_DONE) ||
               (addr_ptr->nlmsg_type == NLMSG_ERROR) ||


### PR DESCRIPTION
Fixed a few warnings that's been annoying me. The majority of warnings left are related to types used in `printf()` (`-Wformat`).