### PR TITLE
make.sh: missing cflags for config2help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ bloatcheck: toybox_old toybox_unstripped
 
 generated/instlist: toybox_stuff
 	NOBUILD=1 scripts/make.sh
-	$(HOSTCC) -I . scripts/install.c -o generated/instlist
+	$(HOSTCC) -I . $(CFLAGS) scripts/install.c -o generated/instlist
 
 install_flat: generated/instlist
 	scripts/install.sh --symlink --force

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -213,7 +213,7 @@ fi
 echo "generated/help.h"
 if [ generated/config2help -ot scripts/config2help.c ]
 then
-  do_loudly $HOSTCC scripts/config2help.c -I . lib/xwrap.c lib/llist.c \
+  do_loudly $HOSTCC scripts/config2help.c $CFLAGS -I . lib/xwrap.c lib/llist.c \
     lib/lib.c lib/portability.c -o generated/config2help || exit 1
 fi
 generated/config2help Config.in $KCONFIG_CONFIG > generated/help.h || exit 1


### PR DESCRIPTION
config2help might require extra parameters to be passed to the compiler. 
For example it might need an additional header path.
