### PR TITLE
toybox: blkid: Properly distinguish ext2/ext3/ext4

### DIFF
--- a/toys/other/blkid.c
+++ b/toys/other/blkid.c
@@ -99,7 +99,7 @@ static void do_blkid(int fd, char *name)
 
   // distinguish ext2/3/4
   type = fstypes[i].name;
-  if (!i) {
+  if (!strcmp(type, "ext2")) {
     if (toybuf[1116]&4) type = "ext3";
     if (toybuf[1120]&64) type = "ext4";
   }


### PR DESCRIPTION
Current code relies on ext2 being at index 0 in the fstype array.  That
assumption was broken with upstream commit 1203ddf.  Instead, let's
compare against the fstype name so we don't rely on ordering.

Change-Id: Ie59ae9e85e5070f24e2069e57b660eac9e08a3a3