### PR TITLE
main.c: fix non-root usage when installed suid root

### DIFF
--- a/main.c
+++ b/main.c
@@ -107,7 +107,7 @@ void toy_init(struct toy_list *which, char *argv[])
 
     if (!(which->flags & TOYFLAG_STAYROOT)) {
       if (uid != euid) {
-        if (!setuid(uid)) perror_exit("setuid %d->%d", euid, uid); // drop root
+        if (setuid(uid)) perror_exit("setuid %d->%d", euid, uid); // drop root
         euid = uid;
         toys.wasroot++;
       }


### PR DESCRIPTION
When toybox is installed suid root and invoked by a non-root user for
commands which do not require root privileges, it drops the root
privileges during initialization.

However, since commit afba5b8efd the result check of setuid() was
inverted such that it aborted on success, making toybox unusuable for
non-root users.

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
