### PR TITLE
Rename basename_r to basename_readonly to avoid Bionic and FreeBSD conflict

### DIFF
--- a/lib/lib.c
+++ b/lib/lib.c
@@ -919,7 +919,7 @@ void mode_to_string(mode_t mode, char *buf)
   *buf = c;
 }
 
-char *basename_r(char *name)
+char *basename_readonly(char *name)
 {
   char *s = strrchr(name, '/');
 
@@ -945,7 +945,7 @@ void names_to_pid(char **names, int (*callback)(pid_t pid, char *name))
 
     for (curname = names; *curname; curname++)
       if (**curname == '/' ? !strcmp(cmd, *curname)
-          : !strcmp(basename_r(cmd), basename_r(*curname)))
+          : !strcmp(basename_readonly(cmd), basename_readonly(*curname)))
         if (callback(u, *curname)) break;
     if (*curname) break;
   }

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -286,7 +286,7 @@ char *num_to_sig(int sig);
 
 mode_t string_to_mode(char *mode_str, mode_t base);
 void mode_to_string(mode_t mode, char *buf);
-char *basename_r(char *name);
+char *basename_readonly(char *name);
 void names_to_pid(char **names, int (*callback)(pid_t pid, char *name));
 
 pid_t xvforkwrap(pid_t pid);

--- a/lib/portability.h
+++ b/lib/portability.h
@@ -157,17 +157,9 @@ int utimensat(int fd, const char *path, const struct timespec times[2], int flag
 
 #endif // glibc in general
 
-#if !defined(__GLIBC__) && !defined(__BIONIC__)
+#if !defined(__GLIBC__)
 // POSIX basename.
 #include <libgen.h>
-#endif
-
-// glibc was handled above; for 32-bit bionic we need to avoid a collision
-// with toybox's basename_r so we can't include <libgen.h> even though that
-// would give us a POSIX basename(3).
-#if defined(__BIONIC__)
-char *basename(char *path);
-char *dirname(char *path);
 #endif
 
 // Work out how to do endianness

--- a/main.c
+++ b/main.c
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 
     toys.stacktop = &stack;
   }
-  *argv = basename_r(*argv);
+  *argv = basename_readonly(*argv);
 
   // If nommu can't fork, special reentry path.
   // Use !stacktop to signal "vfork happened", both before and after xexec()

--- a/toys/pending/modprobe.c
+++ b/toys/pending/modprobe.c
@@ -70,7 +70,7 @@ static char *path2mod(char *file, char *mod)
   if (!file) return NULL;
   if (!mod) mod = xmalloc(MODNAME_LEN);
 	
-  from = basename_r(file);
+  from = basename_readonly(file);
   
   for (i = 0; i < (MODNAME_LEN-1) && from[i] && from[i] != '.'; i++)
     mod[i] = (from[i] == '-') ? '_' : from[i];

--- a/toys/pending/netstat.c
+++ b/toys/pending/netstat.c
@@ -440,7 +440,7 @@ static void scan_pid(int pid)
 
   if ((p = strchr(line, ' '))) *p = 0; // "/bin/netstat -ntp" -> "/bin/netstat"
   snprintf(TT.current_name, sizeof(TT.current_name), "%d/%s",
-           pid, basename_r(line)); // "584/netstat"
+           pid, basename_readonly(line)); // "584/netstat"
   free(line);
 
   fd_dir = xmprintf("/proc/%d/fd", pid);


### PR DESCRIPTION
As suggested in the "FreeBSD porting, removing bashisms" thread.