### PR TITLE
Fix "touch -t" seconds parsing

### DIFF
--- a/tests/touch.test
+++ b/tests/touch.test
@@ -11,6 +11,18 @@ testing "-c" "touch -c walrus && [ -e walrus ] && echo yes" "yes\n" "" ""
 testing "-c missing" "touch -c warrus && [ ! -e warrus ] && echo yes" \
   "yes\n" "" ""
 
+testing "-t" \
+  "touch -t 201201231234 walrus && date -r walrus +%Y%m%d-%H%M%S.%N" \
+  "20120123-123400.000000000\n" "" ""
+
+testing "-t seconds" \
+  "touch -t 201201231234.56 walrus && date -r walrus +%Y%m%d-%H%M%S.%N" \
+  "20120123-123456.000000000\n" "" ""
+
+testing "-t nanoseconds" \
+  "touch -t 201201231234.56123456789 walrus && date -r walrus +%Y%m%d-%H%M%S.%N" \
+  "20120123-123456.123456789\n" "" ""
+
 testing "-d" \
   "touch -d 2009-02-13T23:31:30Z walrus && date -r walrus +%s" \
   "1234567890\n" "" ""

--- a/toys/posix/touch.c
+++ b/toys/posix/touch.c
@@ -80,10 +80,13 @@ void touch_main(void)
         if (s) break;
         toybuf[1]='y';
       }
+      tm.tm_sec = 0;
       ts->tv_nsec = 0;
       if (s && *s=='.' && sscanf(s, ".%2u%n", &(tm.tm_sec), &len) == 1) {
-        sscanf(s += len, "%lu%n", &ts->tv_nsec, &len);
-        len++;
+        if (sscanf(s += len, "%lu%n", &ts->tv_nsec, &len) == 1) {
+          s--;
+          len++;
+        } else len = 0;
       } else len = 0;
     }
     if (len) {


### PR DESCRIPTION
Seconds and nanoseconds parsing for `touch -t` was not working.

Command like `touch -t 200902132331.30 walrus` led to errors like `touch: bad '200902132331.30'`. 

This was caused by two factors:
* When seconds were present, but nanoseconds were **not** present `sscanf(s += len, "%lu%n", &ts->tv_nsec, &len)` was called, but did not set `len` to proper zero. This led to `s` being increased beyond the null terminator of the string by the further code.
* When seconds and nanoseconds were present `s` was not decreased (although `len` was increased for proper trailing zeros calculation by further code). This led to `s` being increased beyond the null terminator of the string by the further code.

In addition `touch -t` without seconds did **not** set seconds to zero. This was fixed as well.

Additionally tests for `touch -t` were added.