### PR TITLE
Fix dangling link after cp command

### DIFF
--- a/toys/posix/cp.c
+++ b/toys/posix/cp.c
@@ -252,7 +252,8 @@ int cp_node(struct dirtree *try)
         // make symlink, or make block/char/fifo/socket
         if (S_ISLNK(try->st.st_mode)
             ? (0 < (i = readlinkat(tfd, try->name, toybuf, sizeof(toybuf))) &&
-               sizeof(toybuf) > i && !symlinkat(toybuf, cfd, catch))
+               sizeof(toybuf) > i && !(toybuf[i] = '\0') &&
+			   !symlinkat(toybuf, cfd, catch))
             : !mknodat(cfd, catch, try->st.st_mode, try->st.st_rdev))
         {
           err = 0;


### PR DESCRIPTION
"toybuf" should be initialized before calling symlinkat() or
dangling link could occur.
