### PR TITLE
Fix use-after-free in sed 'a\' found by ASan

### DIFF
--- a/toys/posix/id.c
+++ b/toys/posix/id.c
@@ -73,7 +73,8 @@ static void s_or_u(char *s, unsigned u, int done)
   else printf("%u", u);
   if (done) {
     xputc('\n');
-    exit(0);
+    toys.exitval = 0;
+    xexit();
   }
 }
 
@@ -143,7 +144,8 @@ static void do_id(char *username)
     }
     if (toys.optflags&FLAG_G) {
       xputc('\n');
-      exit(0);
+      toys.exitval = 0;
+      xexit();
     }
   }
 

--- a/toys/posix/sed.c
+++ b/toys/posix/sed.c
@@ -635,8 +635,6 @@ writenow:
   if (line && !(toys.optflags & FLAG_n)) emit(line, len, eol);
 
 done:
-  free(line);
-
   if (dlist_terminate(append)) while (append) {
     struct append *a = append->next;
 
@@ -655,6 +653,7 @@ done:
     free(append);
     append = a;
   }
+  free(line);
 }
 
 // Genericish function, can probably get moved to lib.c


### PR DESCRIPTION
Full ASan trace:
```
=================================================================
==7611==ERROR: AddressSanitizer: heap-use-after-free on address 0x60c00000be00 at pc 0x000000406678 bp 0x7ffd164fac60 sp 0x7ffd164fac50
READ of size 1 at 0x60c00000be00 thread T0
    #0 0x406677 in emit toys/posix/sed.c:205

0x60c00000be00 is located 0 bytes inside of 120-byte region [0x60c00000be00,0x60c00000be78)
freed by thread T0 here:
    #0 0x7f1444e4b77a in __interceptor_free (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x9877a)
    #1 0x408507 in process_line toys/posix/sed.c:638
    #2 0x7ffd164faf57  (<unknown module>)
    #3 0x7ffd164fb98e  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x7f1444e4bab2 in malloc (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x98ab2)
    #1 0x7f1444a810e7 in getdelim (/lib64/libc.so.6+0x670e7)
    #2 0x405f0c in do_lines toys/posix/sed.c:673

SUMMARY: AddressSanitizer: heap-use-after-free toys/posix/sed.c:205 emit
Shadow bytes around the buggy address:
  0x0c187fff9770: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c187fff9780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c187fff9790: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c187fff97a0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c187fff97b0: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
=>0x0c187fff97c0:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa
  0x0c187fff97d0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c187fff97e0: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
  0x0c187fff97f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c187fff9800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c187fff9810: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
```