### PR TITLE
Fix memory leak in id found by LSan

### DIFF
--- a/toys/posix/id.c
+++ b/toys/posix/id.c
@@ -73,7 +73,8 @@ static void s_or_u(char *s, unsigned u, int done)
   else printf("%u", u);
   if (done) {
     xputc('\n');
-    exit(0);
+    toys.exitval = 0;
+    xexit();
   }
 }
 
@@ -143,7 +144,8 @@ static void do_id(char *username)
     }
     if (toys.optflags&FLAG_G) {
       xputc('\n');
-      exit(0);
+      toys.exitval = 0;
+      xexit();
     }
   }
 


### PR DESCRIPTION
Full LSan log:
```
$ ./generated/unstripped/toybox id -u
1000

=================================================================
==32119==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f331a5c3ab2 in malloc (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x98ab2)
    #1 0x411b20 in xmalloc lib/xwrap.c:64

Indirect leak of 400 byte(s) in 5 object(s) allocated from:
    #0 0x7f331a5c3ab2 in malloc (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x98ab2)
    #1 0x411b20 in xmalloc lib/xwrap.c:64

SUMMARY: AddressSanitizer: 480 byte(s) leaked in 6 allocation(s).
```
