### PR TITLE
Fix a bug for sort.

### DIFF
--- a/toys/posix/sort.c
+++ b/toys/posix/sort.c
@@ -115,7 +115,10 @@ static char *get_key_data(char *str, struct sort_key *key, int flags)
         // Skip body of key
         for (; str[end]; end++) {
           if (TT.key_separator) {
-            if (str[end]==*TT.key_separator) break;
+            if (str[end]==*TT.key_separator) {
+              end++;
+              break;
+            }
           } else if (isspace(str[end])) break;
         }
       }


### PR DESCRIPTION
When the key_separator is not space, the sort commandline tool fails to sort by the 3rd,4th,etc column.
For example:
	when you exec

	  $ sort -t',' -k 3n

	on a file which cotains:

	1,2,3,4
	2,3,4,1
	4,1,2,3
	3,4,1,2

	you got:

	4,1,2,3
	1,2,3,4
	2,3,4,1
	3,4,1,2

	but the expected output should be:

	3,4,1,2
	4,1,2,3
	1,2,3,4
	2,3,4,1

The bug is due to the dependency of "isspace(str[end])" at line 113.
When searching for the non-space key_separator, the search stopped just at the position of first key_separator it met.
The bug can be easily fixed by adding "end++" when the search have found one separator and exit the for loop.