### PR TITLE
Fix variables in help.txt

### DIFF
--- a/scripts/help.txt
+++ b/scripts/help.txt
@@ -11,12 +11,12 @@
                     to show diff, VERBOSE=fail to stop after first failure.
   clean           - Delete temporary files.
   distclean       - Delete everything that isn't shipped.
-  install_airlock - Install toybox and host toolchain into $$PREFIX directory
-                    (providing $$PATH for hermetic builds).
-  install_flat    - Install toybox into $$PREFIX directory.
-  install         - Install toybox into subdirectories of $$PREFIX.
-  uninstall_flat  - Remove toybox from $$PREFIX directory.
-  uninstall       - Remove toybox from subdirectories of $$PREFIX.
+  install_airlock - Install toybox and host toolchain into $PREFIX directory
+                    (providing $PATH for hermetic builds).
+  install_flat    - Install toybox into $PREFIX directory.
+  install         - Install toybox into subdirectories of $PREFIX.
+  uninstall_flat  - Remove toybox from $PREFIX directory.
+  uninstall       - Remove toybox from subdirectories of $PREFIX.
 
 example: CFLAGS="--static" CROSS_COMPILE=armv5l- make defconfig toybox install
 


### PR DESCRIPTION
After replacing `echo TXT` with `cat FILE` in Makefile we don't need double dollar signs anymore.