### PR TITLE
Fix typos: e.g. change "cannonical" to "canonical".

### DIFF
--- a/lib/xwrap.c
+++ b/lib/xwrap.c
@@ -504,7 +504,7 @@ void xstat(char *path, struct stat *st)
   if(stat(path, st)) perror_exit("Can't stat %s", path);
 }
 
-// Cannonicalize path, even to file with one or more missing components at end.
+// Canonicalize path, even to file with one or more missing components at end.
 // if exact, require last path component to exist
 char *xabspath(char *path, int exact)
 {

--- a/toys/other/readlink.c
+++ b/toys/other/readlink.c
@@ -12,7 +12,7 @@ config READLINK
 
     With no options, show what symlink points to, return error if not symlink.
 
-    Options for producing cannonical paths (all symlinks/./.. resolved):
+    Options for producing canonical paths (all symlinks/./.. resolved):
 
     -e	Canonical path to existing entry (fail if missing)
     -f	Full path (fail if directory missing)
@@ -28,7 +28,7 @@ void readlink_main(void)
 {
   char *s;
 
-  // Calculating full cannonical path?
+  // Calculating full canonical path?
   // Take advantage of flag positions to calculate m = -1, f = 0, e = 1
   if (toys.optflags & (FLAG_f|FLAG_e|FLAG_m))
     s = xabspath(*toys.optargs, (toys.optflags&(FLAG_f|FLAG_e))-1);

--- a/toys/posix/pwd.c
+++ b/toys/posix/pwd.c
@@ -15,7 +15,7 @@ config PWD
     Print working (current) directory.
 
     -L	Use shell's path from $PWD (when applicable)
-    -P	Print cannonical absolute path
+    -P	Print canonical absolute path
 */
 
 #define FOR_pwd

--- a/www/news.html
+++ b/www/news.html
@@ -42,7 +42,7 @@ arguments, <b>cmp</b> accepts --quiet and --silent as synonyms for -s, <b>hostna
 added -sfd, <b>head</b> added --bytes as a synonym for -c and --lines as a synonym
 for -n, <b>mktemp</b> added -t and fixed -u, <b>sed</b> added -z and -iEXT to keep backup files,
 <b>md5sum</b> and sha1sum added --status and --check as synonyms -s and -c,
-<b>readlink</b> added --cannonicalize as a synonym for -f, <b>sort</b> grew -V,
+<b>readlink</b> added --canonicalize as a synonym for -f, <b>sort</b> grew -V,
 <b>patch</b> added -s its synonym --quiet, <b>stat</b> added --format as
 a synonym for -c, <b>xargs</b> added -p -t -r,
 Eduardas Meile asked


### PR DESCRIPTION
# Background

The actual runnable code has never misspelled "canonical" or "canonicalize", but some code comments (and www/news.html) have occasionally misspelled one or both words.

This pull request fixes the misspellings.

# Possible memory aid

Here's a **possible memory aid** which might help you in the future:

A "canonical" path is an official, authoritative path, as in "canon law".  A "cannonical" path is a trail you can use to transport heavy artillery which can shoot cannonballs at an enemy army.

So, canons improve your paths, but cannons explode and destroy them.

# Conclusion

Thank you for continuing to maintain `toybox`!  I still don't miss the old Android `toolbox` at all.