### PR TITLE
find: fix inverted -exec exit status

### DIFF
--- a/tests/find.test
+++ b/tests/find.test
@@ -56,6 +56,10 @@ testing "-type f -user -exec" \
   "find dir -type f -user $USER -exec ls {} \\;" "dir/file\n" "" ""
 testing "-type l -newer -exec" \
   "find dir -type l -newer dir/file -exec ls {} \\;" "dir/link\n" "" ""
+testing "-exec true \\; -print" \
+  "find dir/file -exec true \\; -print" "dir/file\n" "" ""
+testing "-exec false \\; -print" \
+  "find dir/file -exec false \\; -print" "" "" ""
 testing "-perm (exact success)" \
   "find perm -type f -perm 0444" "perm/all-read-only\n" "" ""
 testing "-perm (exact failure)" \

--- a/toys/posix/find.c
+++ b/toys/posix/find.c
@@ -530,7 +530,7 @@ static int do_find(struct dirtree *new)
               aa->plus = 1;
               toys.exitval |= flush_exec(new, aa);
             }
-          } else test = flush_exec(new, aa);
+          } else test = !flush_exec(new, aa);
         }
 
         // Argument consumed, skip the check.


### PR DESCRIPTION
The return value of -exec was the command's exit code, which did not
account for the fact that an exit code of zero means success, while in
C, zero means failure. From POSIX:

>  the primary shall evaluate as true if the utility returns a zero
>  value as exit status

This commit flips the return value, and adds two tests.

This fixes https://github.com/landley/toybox/issues/124