### PR TITLE
Make mktemp --tmpdir's argument optional

### DIFF
--- a/toys/lsb/mktemp.c
+++ b/toys/lsb/mktemp.c
@@ -4,7 +4,7 @@
  *
  * http://refspecs.linuxfoundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/mktemp.html
 
-USE_MKTEMP(NEWTOY(mktemp, ">1uqd(directory)p(tmpdir):t", TOYFLAG_BIN))
+USE_MKTEMP(NEWTOY(mktemp, ">1uqd(directory)p(tmpdir):;t", TOYFLAG_BIN))
 
 config MKTEMP
   bool "mktemp"


### PR DESCRIPTION
This matches GNU mktemp which has an optional argument for --tmpdir