### PR TITLE
Add ln -r

### DIFF
--- a/toys/posix/ln.c
+++ b/toys/posix/ln.c
@@ -77,10 +77,14 @@ void ln_main(void)
       s = getdirname(new);
       abs = xmprintf("%s/%s", xabspath(s, -1), getbasename(new));
       free(s);
-      rc = common_path(try, abs);
-      try += rc;
-      abs += rc;
-      for (;*abs; abs++) if (*abs == '/') try = xmprintf("../%s", try);
+
+      // avoid stripping common path if source and target are the same file
+      if (strcmp(try, abs)) {
+        rc = common_path(try, abs);
+        try += rc;
+        abs += rc;
+        for (;*abs; abs++) if (*abs == '/') try = xmprintf("../%s", try);
+      }
     }
 
     // Force needs to unlink the existing target (if any). Do that by creating

--- a/toys/posix/ln.c
+++ b/toys/posix/ln.c
@@ -63,8 +63,9 @@ void ln_main(void)
       if (FLAG(s)) {
         int j = 0, k;
         // absolute paths needed for comparison
-        char *s = getdirname(new), *ss, *try2 = xabspath(try, -1)
-          *abs = xmprintf("%s/%s", ss = xabspath(s, -1), getbasename(new));
+        char *s = xstrdup(new), *ss = xabspath(dirname(s), -1),
+          *try2 = xabspath(try, -1),
+          *abs = xmprintf("%s/%s", ss, getbasename(new));
 
         free(s);
         free(ss);


### PR DESCRIPTION
I had to make getdirname return "." instead of the file when the path has no '/', like dirname does, for my code to work correctly. I checked the new flag and toybox ln in general against GNU's ln tests.
Use cases:
https://git.archlinux.org/svntogit/packages.git/tree/trunk/update-ca-trust?h=packages/ca-certificates#n38
https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/linux#n201
