### PR TITLE
Fix getopt optstring

### DIFF
--- a/tests/getopt.test
+++ b/tests/getopt.test
@@ -30,7 +30,7 @@ test_getopt "-o a -l one:: -- -a --one arg" " -a --one '' -- 'arg'"
 test_getopt "-o a -l one:: -- -a --one=arg" " -a --one 'arg' --"
 
 # "Alternative" long options (-like -this but also --like --this).
-test_getopt "-o a -a -l long -- -long --long a" " --long --long -- 'a'"
+test_getopt "--options a -a --longoptions long -- -long --long a" " --long --long -- 'a'"
 
 # -u lets you avoid quoting even with modern -o.
 test_getopt "-u -o a: -- -a b c" " -a b -- c"

--- a/toys/pending/getopt.c
+++ b/toys/pending/getopt.c
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 The Android Open Source Project
 
-USE_GETOPT(NEWTOY(getopt, "^(alternative)a(name)n:(options)o:(long)(longoptions)l*Tu", TOYFLAG_USR|TOYFLAG_BIN))
+USE_GETOPT(NEWTOY(getopt, "^a(alternative)n:(name)o:(options)l*(long)(longoptions)Tu", TOYFLAG_USR|TOYFLAG_BIN))
 
 config GETOPT
   bool "getopt"


### PR DESCRIPTION
Move longopts after their corresponding shortopts instead of before