### PR TITLE
fix loopback device mount fail

### DIFF
--- a/toys/lsb/mount.c
+++ b/toys/lsb/mount.c
@@ -270,6 +270,7 @@ static void mount_filesystem(char *dev, char *dir, char *type,
       dev = tortoise(1, (char *[]){"losetup",
         (flags&MS_RDONLY) ? "-fsr" : "-fs", dev, 0});
       if (!dev) break;
+      continue;
     }
 
     free(buf);


### PR DESCRIPTION
When we "losetup" success need mount loop device.
Found this issue on AndroidQ

Relate to commit 8a9484e8bfbfc8cd