### PR TITLE
tar: fix memory write error

### DIFF
--- a/toys/posix/tar.c
+++ b/toys/posix/tar.c
@@ -169,7 +169,7 @@ static void alloread(void *buf, int len)
   free(*b);
   *b = xmalloc(len+1);
   xreadall(TT.fd, *b, len);
-  b[len] = 0;
+  ((char*)(*b))[len] = 0;
 }
 
 // callback from dirtree to create archive


### PR DESCRIPTION
Clear the last byte of the allocated buffer.

The allocated buffer is referenced by `*b`. `b[len] = 0` overwrites sizeof(void*) bytes of the wrong piece of memory.