### PR TITLE
lib/env: avoid use-after-free in xclearenv

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -29,7 +29,7 @@ void xclearenv(void)
     free(environ);
   }
   toys.envc = 0;
-  *environ = 0;
+  environ = 0;
 }
 
 // Frees entries we set earlier. Use with libc getenv but not setenv/putenv.


### PR DESCRIPTION
In `xclearenv`, `char **environ` is either NULL or it is freed.  Afterward,
it is dereferenced.  It appears that the intention was to NULL out the
variable, not write a NULL to the now-dangling array.

Signed-off-by: Derrick Pallas <derrick@pallas.us>