### PR TITLE
Convert scripts (aside from the ones used for testing) to POSIX sh

### DIFF
--- a/configure
+++ b/configure
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # This sets environment variables used by scripts/make.sh
 
 # People run ./configure out of habit, so do "defconfig" for them.
 
-if [ "$(basename "$0")" == configure ]
+if [ "${0##*/}" = configure ]
 then
   echo "Assuming you want 'make defconfig', but you should probably check the README."
   make defconfig

--- a/scripts/bloatcheck
+++ b/scripts/bloatcheck
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ $# -ne 2 ]
 then
@@ -40,7 +40,7 @@ do_bloatcheck()
     fi
 
     SIZE=$(printf "%d" "0x$b")
-    if [ "$a" == "-" ]
+    if [ "$a" = "-" ]
     then
       OLD=$(($OLD+$SIZE))
       SIZE=$((-1*$SIZE))

--- a/scripts/change.sh
+++ b/scripts/change.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # build each command as a standalone executable
 
@@ -14,8 +14,8 @@ mkdir -p "$PREFIX" || exit 1
 
 for i in $(generated/instlist | egrep -vw "sh|help")
 do
-  echo -n " $i" &&
+  printf ' %s' "$i" &&
   scripts/single.sh $i > /dev/null 2>$PREFIX/${i}.bad &&
-    rm $PREFIX/${i}.bad || echo -n '*'
+    rm $PREFIX/${i}.bad || printf '*'
 done
 echo

--- a/scripts/findglobals.sh
+++ b/scripts/findglobals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Quick and dirty check to see if anybody's leaked global variables.
 # We should have this, toy_list, toybuf, and toys.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Grab default values for $CFLAGS and such.
 
-source ./configure
+. ./configure
 
 [ -z "$PREFIX" ] && PREFIX="/usr/toybox"
 
@@ -12,19 +12,19 @@ LONG_PATH=""
 while [ ! -z "$1" ]
 do
   # Create symlinks instead of hardlinks?
-  [ "$1" == "--symlink" ] && LINK_TYPE="-s"
+  [ "$1" = "--symlink" ] && LINK_TYPE="-s"
 
   # Uninstall?
-  [ "$1" == "--uninstall" ] && UNINSTALL=Uninstall
+  [ "$1" = "--uninstall" ] && UNINSTALL=Uninstall
 
   # Delete destination command if it exists?
-  [ "$1" == "--force" ] && DO_FORCE="-f"
+  [ "$1" = "--force" ] && DO_FORCE="-f"
 
   # Use {,usr}/{bin,sbin} paths instead of all files in one directory?
-  [ "$1" == "--long" ] && LONG_PATH="bin/"
+  [ "$1" = "--long" ] && LONG_PATH="bin/"
 
   # Symlink host toolchain binaries to destination to create cross compile $PATH
-  [ "$1" == "--airlock" ] && AIRLOCK=1
+  [ "$1" = "--airlock" ] && AIRLOCK=1
 
   shift
 done
@@ -133,8 +133,7 @@ then
         ln -sf "$j" "$FALLBACK/$i" || exit 1
       fi
 
-      X=$[$X+1]
-      FALLBACK="$PREFIX/fallback-$X"
+      FALLBACK="$PREFIX/fallback-$((X += 1))"
     done
 
     if [ ! -f "$PREFIX/$i" ]

--- a/scripts/minicom.sh
+++ b/scripts/minicom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # If you want to use toybox netcat to talk to a serial port, use this.
 

--- a/scripts/mkroot.sh
+++ b/scripts/mkroot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Clear environment variables by restarting script w/bare minimum passed through
 # set ALL= LINUX= CROSS= on command line
@@ -6,12 +6,12 @@
     CROSS_COMPILE="$CROSS_COMPILE" "$0" "$@"
 
 die() { echo "$@" >&2; exit 1; }
-announce() { echo -e "\033]2;$CROSS $*\007\n=== $*"; }
+announce() { printf '\033]2;%s %s\007\n=== %s\n' "$CROSS" "$*" "$*"; }
 getcross() { X="$(echo "$CCC/$1"-*cross/bin/"$1"*-cc)"; echo "${X%cc}"; }
 
 # assign command line NAME=VALUE args to env vars
 while [ $# -ne 0 ]; do
-  [ "${1/=/}" != "$1" ] && eval "export ${1/=*/}=\"\${1#*=}\"" || PKG="$PKG $i"
+  [ "${1#*=}" != "$1" ] && eval "export ${1%%=*}=\"\${1#*=}\"" || PKG="$PKG $i"
   shift
 done
 
@@ -22,13 +22,13 @@ mkdir -p ${BUILD:=$TOP/build} ${AIRLOCK:=$TOP/airlock} ${LOG:=$TOP/log} ||exit 1
 # set CROSS_COMPILE from $CROSS using ccc. Handle "all" w/log, list, and err chk
 if [ ! -z "$CROSS" ]; then
   [ ! -d "${CCC:=$PWD/ccc}" ] && die "No ccc symlink to compiler directory."
-  if [ "$CROSS" == all ]; then
+  if [ "$CROSS" = all ]; then
     for i in $(ls "$CCC" | sed -n 's/-.*//p' | sort -u | xargs); do
-      { rm -f "$LOG/$i-log".{failed,success}
-        "$0" "$@" CROSS=$i ; [ $((X=$?)) -eq 0 ] && mv "$LOG/$i".{txt,success}
-      } |& tee "$LOG/$i.txt"
+      { rm -f "$LOG/$i-log.failed" "$LOG/$i-log.success"
+        "$0" "$@" CROSS=$i ; [ $((X=$?)) -eq 0 ] && mv "$LOG/$i.txt" "$LOG/$i.success"
+      } 2>&1 | tee "$LOG/$i.txt"
       [ ! -e "$LOG/$i.success" ] &&
-        { mv "$LOG/$i".{txt,failed};[ -z "$ALL" ] && exit 1; }
+        { mv "$LOG/$i.txt" "$LOG/$i.failed";[ -z "$ALL" ] && exit 1; }
     done; exit
   elif [ ! -e "${CROSS_COMPILE:=$(getcross $CROSS)}cc" ]; then
     ls "$CCC" | sed -n 's/-.*//p' | sort -u | xargs; exit
@@ -37,14 +37,14 @@ fi
 
 # Digest $CROSS_COMPILE (if any) into appropriate environment variables.
 if [ -z "$CROSS_COMPILE" ]; then
-  if ! cc --static -xc - -o /dev/null <<< "int main(void) {return 0;}"; then
+    if ! echo 'int main(void) {return 0;}' | cc --static -xc - -o /dev/null; then
     echo "Warning: host compiler can't create static binaries." >&2; sleep 3
   fi
 else
   CROSS_PATH="$(dirname "$(which "${CROSS_COMPILE}cc")")"
   CROSS_BASE="$(basename "$CROSS_COMPILE")"
   [ -z "$CROSS_PATH" ] && die "no ${CROSS_COMPILE}cc in path"
-  : ${CROSS:=${CROSS_BASE/-*/}}
+  : ${CROSS:=${CROSS_BASE%%-*}}
 fi
 echo "Building for ${CROSS:=host}"
 
@@ -64,8 +64,10 @@ if [ ! -z "$CROSS_COMPILE" ]; then
 fi
 
 # directory layout
-mkdir -p "$ROOT"/{etc,tmp,proc,sys,dev,home,mnt,root,usr/{bin,sbin,lib},var} &&
-chmod a+rwxt "$ROOT"/tmp && ln -s usr/{bin,sbin,lib} "$ROOT" || exit 1
+mkdir -p "$ROOT/etc" "$ROOT/tmp" "$ROOT/proc" "$ROOT/sys" "$ROOT/dev" \
+   "$ROOT/home" "$ROOT/mnt" "$ROOT/root" "$ROOT/usr/bin" "$ROOT/usr/sbin" \
+   "$ROOT/usr/lib" "$ROOT/var"
+chmod a+rwxt "$ROOT"/tmp && ln -s usr/bin usr/sbin usr/lib "$ROOT" || exit 1
 
 # init script. Runs as pid 1 from initramfs to set up and hand off system.
 cat > "$ROOT"/init << 'EOF' &&
@@ -112,7 +114,7 @@ root::0:0:root:/root:/bin/sh
 guest:x:500:500:guest:/home/guest:/bin/sh
 nobody:x:65534:65534:nobody:/proc/self:/dev/null
 EOF
-echo -e 'root:x:0:\nguest:x:500:\nnobody:x:65534:' > "$ROOT"/etc/group || exit 1
+printf 'root:x:0:\nguest:x:500:\nnobody:x:65534:\n' > "$ROOT"/etc/group || exit 1
 
 announce toybox
 make clean $([ -z .config ] && echo defconfig || echo silentoldconfig) &&
@@ -122,13 +124,13 @@ if [ -z "$LINUX" ] || [ ! -d "$LINUX/kernel" ]; then
   echo 'No $LINUX directory, kernel build skipped.'
 else
   # Which architecture are we building a kernel for?
-  [ -z "$TARGET" ] && TARGET="${CROSS_BASE/-*/}"
+  [ -z "$TARGET" ] && TARGET="${CROSS_BASE%%-*}"
   [ -z "$TARGET" ] && TARGET="$(uname -m)"
 
   # Target-specific info in an (alphabetical order) if/else staircase
   # Each target needs board config, serial console, RTC, ethernet, block device.
 
-  if [ "$TARGET" == armv5l ]; then
+  if [ "$TARGET" = armv5l ]; then
     # This could use the same VIRT board as armv7, but let's demonstrate a
     # different one requiring a separate device tree binary.
     QEMU="arm -M versatilepb -net nic,model=rtl8139 -net user"
@@ -136,8 +138,8 @@ else
     KCONF=CPU_ARM926T,MMU,VFP,ARM_THUMB,AEABI,ARCH_VERSATILE,ATAGS,DEPRECATED_PARAM_STRUCT,ARM_ATAG_DTB_COMPAT,ARM_ATAG_DTB_COMPAT_CMDLINE_EXTEND,SERIAL_AMBA_PL011,SERIAL_AMBA_PL011_CONSOLE,RTC_CLASS,RTC_DRV_PL031,RTC_HCTOSYS,PCI,PCI_VERSATILE,BLK_DEV_SD,SCSI,SCSI_LOWLEVEL,SCSI_SYM53C8XX_2,SCSI_SYM53C8XX_MMIO,NET_VENDOR_REALTEK,8139CP
     KERNEL_CONFIG="CONFIG_SCSI_SYM53C8XX_DMA_ADDRESSING_MODE=0"
     DTB=arch/arm/boot/dts/versatile-pb.dtb
-  elif [ "$TARGET" == armv7l ] || [ "$TARGET" == aarch64 ]; then
-    if [ "$TARGET" == aarch64 ]; then
+  elif [ "$TARGET" = armv7l ] || [ "$TARGET" = aarch64 ]; then
+    if [ "$TARGET" = aarch64 ]; then
       QEMU="aarch64 -M virt -cpu cortex-a57"
       KARCH=arm64 VMLINUX=arch/arm64/boot/Image
     else
@@ -145,37 +147,37 @@ else
     fi
     KARGS=ttyAMA0
     KCONF=MMU,ARCH_MULTI_V7,ARCH_VIRT,SOC_DRA7XX,ARCH_OMAP2PLUS_TYPICAL,ARCH_ALPINE,ARM_THUMB,VDSO,CPU_IDLE,ARM_CPUIDLE,KERNEL_MODE_NEON,SERIAL_AMBA_PL011,SERIAL_AMBA_PL011_CONSOLE,RTC_CLASS,RTC_HCTOSYS,RTC_DRV_PL031,NET_CORE,VIRTIO_MENU,VIRTIO_NET,PCI,PCI_HOST_GENERIC,VIRTIO_BLK,VIRTIO_PCI,VIRTIO_MMIO,ATA,ATA_SFF,ATA_BMDMA,ATA_PIIX,PATA_PLATFORM,PATA_OF_PLATFORM,ATA_GENERIC
-  elif [ "$TARGET" == i486 ] || [ "$TARGET" == i686 ] ||
-       [ "$TARGET" == x86_64 ] || [ "$TARGET" == x32 ]; then
-    if [ "$TARGET" == i486 ]; then
+  elif [ "$TARGET" = i486 ] || [ "$TARGET" = i686 ] ||
+       [ "$TARGET" = x86_64 ] || [ "$TARGET" = x32 ]; then
+    if [ "$TARGET" = i486 ]; then
       QEMU="i386 -cpu 486 -global fw_cfg.dma_enabled=false" KCONF=M486
-    elif [ "$TARGET" == i686 ]; then
+    elif [ "$TARGET" = i686 ]; then
       QEMU="i386 -cpu pentium3" KCONF=MPENTIUMII
     else
       QEMU=x86_64 KCONF=64BIT
-      [ "$TARGET" == x32 ] && KCONF=X86_X32
+      [ "$TARGET" = x32 ] && KCONF=X86_X32
     fi
     KARCH=x86 KARGS=ttyS0 VMLINUX=arch/x86/boot/bzImage
     KCONF=$KCONF,UNWINDER_FRAME_POINTER,PCI,BLK_DEV_SD,ATA,ATA_SFF,ATA_BMDMA,ATA_PIIX,NET_VENDOR_INTEL,E1000,SERIAL_8250,SERIAL_8250_CONSOLE,RTC_CLASS
-  elif [ "$TARGET" == m68k ]; then
+  elif [ "$TARGET" = m68k ]; then
     QEMU="m68k -M q800" KARCH=m68k KARGS=ttyS0 VMLINUX=vmlinux
     KCONF=MMU,M68040,M68KFPU_EMU,MAC,SCSI_MAC_ESP,MACINTOSH_DRIVERS,ADB,ADB_MACII,NET_CORE,MACSONIC,SERIAL_PMACZILOG,SERIAL_PMACZILOG_TTYS,SERIAL_PMACZILOG_CONSOLE
-  elif [ "$TARGET" == mips ] || [ "$TARGET" == mipsel ]; then
+  elif [ "$TARGET" = mips ] || [ "$TARGET" = mipsel ]; then
     QEMU="mips -M malta" KARCH=mips KARGS=ttyS0 VMLINUX=vmlinux
     KCONF=MIPS_MALTA,CPU_MIPS32_R2,SERIAL_8250,SERIAL_8250_CONSOLE,PCI,BLK_DEV_SD,ATA,ATA_SFF,ATA_BMDMA,ATA_PIIX,NET_VENDOR_AMD,PCNET32,POWER_RESET,POWER_RESET_SYSCON
-    [ "$TARGET" == mipsel ] && KCONF=$KCONF,CPU_LITTLE_ENDIAN &&
+    [ "$TARGET" = mipsel ] && KCONF=$KCONF,CPU_LITTLE_ENDIAN &&
       QEMU="mipsel -M malta"
-  elif [ "$TARGET" == powerpc ]; then
+  elif [ "$TARGET" = powerpc ]; then
     KARCH=powerpc QEMU="ppc -M g3beige" KARGS=ttyS0 VMLINUX=vmlinux
     KCONF=ALTIVEC,PPC_PMAC,PPC_OF_BOOT_TRAMPOLINE,IDE,IDE_GD,IDE_GD_ATA,BLK_DEV_IDE_PMAC,BLK_DEV_IDE_PMAC_ATA100FIRST,MACINTOSH_DRIVERS,ADB,ADB_CUDA,NET_VENDOR_NATSEMI,NET_VENDOR_8390,NE2K_PCI,SERIO,SERIAL_PMACZILOG,SERIAL_PMACZILOG_TTYS,SERIAL_PMACZILOG_CONSOLE,BOOTX_TEXT
-  elif [ "$TARGET" == powerpc64le ]; then
+  elif [ "$TARGET" = powerpc64le ]; then
     KARCH=powerpc QEMU="ppc64 -M pseries -vga none" KARGS=/dev/hvc0
     VMLINUX=vmlinux
     KCONF=PPC64,PPC_PSERIES,CPU_LITTLE_ENDIAN,PPC_OF_BOOT_TRAMPOLINE,BLK_DEV_SD,SCSI_LOWLEVEL,SCSI_IBMVSCSI,ATA,NET_VENDOR_IBM,IBMVETH,HVC_CONSOLE,PPC_TRANSACTIONAL_MEM,PPC_DISABLE_WERROR,SECTION_MISMATCH_WARN_ONLY
   elif [ "$TARGET" = s390x ] ; then
     QEMU="s390x" KARCH=s390 VMLINUX=arch/s390/boot/bzImage
     KCONF=MARCH_Z900,PACK_STACK,NET_CORE,VIRTIO_NET,VIRTIO_BLK,SCLP_TTY,SCLP_CONSOLE,SCLP_VT220_TTY,SCLP_VT220_CONSOLE,S390_GUEST
-  elif [ "$TARGET" == sh4 ] ; then
+  elif [ "$TARGET" = sh4 ] ; then
     QEMU="sh4 -M r2d -serial null -serial mon:stdio" KARCH=sh
     KARGS="ttySC1 noiotrap" VMLINUX=arch/sh/boot/zImage
     KERNEL_CONFIG="CONFIG_MEMORY_START=0x0c000000"
@@ -188,23 +190,24 @@ else
   echo "qemu-system-$QEMU" '"$@"' -nographic -no-reboot -m 256 \
        "-kernel $(basename "$VMLINUX") -initrd ${CROSS_BASE}root.cpio.gz" \
        "-append \"quiet panic=1 HOST=$TARGET console=$KARGS \$KARGS\"" \
-       ${DTB:+-dtb "$(basename "$DTB")"} ";echo -e '\e[?7h'" \
+       ${DTB:+-dtb "$(basename "$DTB")"} ";printf '\033[?7h\n'" \
        > "$OUTPUT/qemu-$TARGET.sh" &&
   chmod +x "$OUTPUT/qemu-$TARGET.sh" &&
 
   announce "linux-$KARCH"
-  pushd "$LINUX" && make distclean && popd &&
-  cp -sfR "$LINUX" "$MYBUILD/linux" && pushd "$MYBUILD/linux" &&
+  dir="$PWD"
+  cd "$LINUX" && make distclean && cd "$dir" &&
+  cp -sfR "$LINUX" "$MYBUILD/linux" && cd "$MYBUILD/linux" &&
 
   # Write miniconfig
   { echo "# make ARCH=$KARCH allnoconfig KCONFIG_ALLCONFIG=$TARGET.miniconf"
-    echo -e "# make ARCH=$KARCH -j \$(nproc)\n# boot $VMLINUX\n\n"
+    printf "# make ARCH=%s -j \$(nproc)\n# boot %s\n\n\n" "$KARCH" "$VMLINUX"
     echo "# CONFIG_EMBEDDED is not set"
 
     # Expand list of =y symbols, first generic then architecture-specific
     for i in EARLY_PRINTK,BINFMT_ELF,BINFMT_SCRIPT,NO_HZ,HIGH_RES_TIMERS,BLK_DEV,BLK_DEV_INITRD,RD_GZIP,BLK_DEV_LOOP,EXT4_FS,EXT4_USE_FOR_EXT2,VFAT_FS,FAT_DEFAULT_UTF8,MISC_FILESYSTEMS,SQUASHFS,SQUASHFS_XATTR,SQUASHFS_ZLIB,DEVTMPFS,DEVTMPFS_MOUNT,TMPFS,TMPFS_POSIX_ACL,NET,PACKET,UNIX,INET,IPV6,NETDEVICES,NET_CORE,NETCONSOLE,ETHERNET $KCONF ; do
       echo "# architecture ${X:-independent}"
-      sed -E '/^$/d;s/([^,]*)($|,)/CONFIG_\1=y\n/g' <<< "$i"
+      echo "$i" | sed -E '/^$/d;s/([^,]*)($|,)/CONFIG_\1=y\n/g'
       X=specific
     done
     echo "$KERNEL_CONFIG"
@@ -213,16 +216,17 @@ else
 
   # Second config pass to remove stupid kernel defaults
   # See http://lkml.iu.edu/hypermail/linux/kernel/1912.3/03493.html
-  sed -e 's/# CONFIG_EXPERT .*/CONFIG_EXPERT=y/' -e "$(sed -E -e '/^$/d' \
-    -e 's@([^,]*)($|,)@/^CONFIG_\1=y/d;$a# CONFIG_\1 is not set/\n@g' \
-       <<< VT,SCHED_DEBUG,DEBUG_MISC,X86_DEBUG_FPU)" -i .config &&
+  sed -e 's/# CONFIG_EXPERT .*/CONFIG_EXPERT=y/' -e "$(echo \
+    'VT,SCHED_DEBUG,DEBUG_MISC,X86_DEBUG_FPU' | sed -E -e '/^$/d' \
+    -e 's@([^,]*)($|,)@/^CONFIG_\1=y/d;$a# CONFIG_\1 is not set/\n@g')" \
+    -i .config &&
   yes "" | make ARCH=$KARCH oldconfig > /dev/null &&
 
   # Build kernel. Copy config, device tree binary, and kernel binary to output
   make ARCH=$KARCH CROSS_COMPILE="$CROSS_COMPILE" -j $(nproc) &&
   cp .config "$OUTPUT/linux-fullconfig" || exit 1
   [ ! -z "$DTB" ] && { cp "$DTB" "$OUTPUT" || exit 1 ;}
-  cp "$VMLINUX" "$OUTPUT" && cd .. && rm -rf linux && popd || exit 1
+  cp "$VMLINUX" "$OUTPUT" && cd .. && rm -rf linux && cd "$dir" || exit 1
 fi
 
 # Build any modules, clean up, and package root filesystem for initramfs.

--- a/scripts/portability.sh
+++ b/scripts/portability.sh
@@ -1,6 +1,6 @@
 # sourced to find alternate names for things
 
-source configure
+. ./configure
 
 if [ -z "$(command -v "${CROSS_COMPILE}${CC}")" ]
 then

--- a/scripts/record-commands
+++ b/scripts/record-commands
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Set up command recording wrapper
 

--- a/scripts/single.sh
+++ b/scripts/single.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Build a standalone toybox command
 
@@ -9,7 +9,7 @@ then
 fi
 
 # Add trailing / to PREFIX when it's set but hasn't got one
-[ "$PREFIX" == "${PREFIX%/}" ] && PREFIX="${PREFIX:+$PREFIX/}"
+[ "$PREFIX" = "${PREFIX%/}" ] && PREFIX="${PREFIX:+$PREFIX/}"
 
 # Harvest TOYBOX_* symbols from .config
 if [ ! -e .config ]
@@ -24,7 +24,7 @@ touch -c .config
 export KCONFIG_CONFIG=.singleconfig
 for i in "$@"
 do
-  echo -n "$i:"
+  printf '%s:' "$i"
   TOYFILE="$(egrep -l "TOY[(]($i)[ ,]" toys/*/*.c)"
 
   if [ -z "$TOYFILE" ]
@@ -37,7 +37,7 @@ do
 
   DEPENDS=
   MPDEL=
-  if [ "$i" == sh ]
+  if [ "$i" = sh ]
   then
     DEPENDS="$(sed -n 's/USE_\([^(]*\)(NEWTOY([^,]*,.*TOYFLAG_MAYFORK.*/\1/p' toys/*/*.c)"
   else


### PR DESCRIPTION
This partially addresses #77, because while tests still require bash, building can now be done without it.