### PR TITLE
silence -Wstring-plus-int warnings throughout source, remove -Wno-string-plus-int

### DIFF
--- a/lib/lib.c
+++ b/lib/lib.c
@@ -444,7 +444,7 @@ int unescape2(char **c, int echo)
   if (idx != '\\' || !**c) return idx;
   if (**c == 'c') return 31&*(++*c);
   for (i = 0; i<4; i++) {
-    if (sscanf(*c, (char *[]){"0%3o%n"+!echo, "x%2x%n", "u%4x%n", "U%6x%n"}[i],
+    if (sscanf(*c, (char *[]){&"0%3o%n"[!echo], "x%2x%n", "u%4x%n", "U%6x%n"}[i],
         &idx, &off))
     {
       *c += off;
@@ -1214,7 +1214,7 @@ char *show_uuid(char *uuid)
   char *out = libbuf;
   int i;
 
-  for (i=0; i<16; i++) out+=sprintf(out, "-%02x"+!(0x550&(1<<i)), uuid[i]);
+  for (i=0; i<16; i++) out+=sprintf(out, &"-%02x"[!(0x550&(1<<i))], uuid[i]);
   *out = 0;
 
   return libbuf;

--- a/scripts/genconfig.sh
+++ b/scripts/genconfig.sh
@@ -7,16 +7,12 @@ mkdir -p generated
 
 source scripts/portability.sh
 
-probecc()
-{
-  ${CROSS_COMPILE}${CC} $CFLAGS -xc -o /dev/null $1 -
-}
-
 # Probe for a single config symbol with a "compiles or not" test.
 # Symbol name is first argument, flags second, feed C file to stdin
 probesymbol()
 {
-  probecc $2 2>/dev/null && DEFAULT=y || DEFAULT=n
+  ${CROSS_COMPILE}${CC} $CFLAGS -xc -o /dev/null $2 - 2>/dev/null &&
+    DEFAULT=y || DEFAULT=n
   rm a.out 2>/dev/null
   echo -e "config $1\n\tbool" || exit 1
   echo -e "\tdefault $DEFAULT\n" || exit 1
@@ -25,11 +21,6 @@ probesymbol()
 probeconfig()
 {
   > generated/cflags
-  # llvm produces its own really stupid warnings about things that aren't wrong,
-  # and although you can turn the warning off, gcc reacts badly to command line
-  # arguments it doesn't understand. So probe.
-  [ -z "$(probecc -Wno-string-plus-int <<< \#warn warn 2>&1 | grep string-plus-int)" ] &&
-    echo -Wno-string-plus-int >> generated/cflags
 
   # Probe for container support on target
   probesymbol TOYBOX_CONTAINER << EOF

--- a/toys/lsb/gzip.c
+++ b/toys/lsb/gzip.c
@@ -121,7 +121,7 @@ static void do_gzip(int ifd, char *in)
   // Are we writing to stdout?
   if (!ifd || FLAG(c)) ofd = 1;
   if (isatty(ifd)) {
-    if (!FLAG(f)) return error_msg("%s:need -f to read TTY"+3*!!ifd, in);
+    if (!FLAG(f)) return error_msg(&"%s:need -f to read TTY"[3*!!ifd], in);
     else ofd = 1;
   }
 

--- a/toys/lsb/pidof.c
+++ b/toys/lsb/pidof.c
@@ -31,10 +31,10 @@ static int print_pid(pid_t pid, char *name)
 {
   sprintf(toybuf, "%d", (int)pid);
   if (comma_scan(TT.omit, toybuf, 0)) return 0;
-  xprintf(" %s"+!!toys.exitval, toybuf);
+  xprintf(&" %s"[!!toys.exitval], toybuf);
   toys.exitval = 0;
 
-  return toys.optflags & FLAG_s;
+  return FLAG(s);
 }
 
 void pidof_main(void)

--- a/toys/net/ifconfig.c
+++ b/toys/net/ifconfig.c
@@ -120,7 +120,7 @@ static void display_ifconfig(char *name, int always, unsigned long long val[])
   flags = ifre.ifr_flags;
   if (!always && !(flags & IFF_UP)) return;
 
-  if (toys.optflags&FLAG_S) {
+  if (FLAG(S)) {
     unsigned uu = 0;
     int len;
 
@@ -137,15 +137,15 @@ static void display_ifconfig(char *name, int always, unsigned long long val[])
   // Not xioctl because you don't have permission for this on Android.
   ioctl(TT.sockfd, SIOCGIFHWADDR, &ifre);
 
-  if (toys.optflags&FLAG_S)
-    for (i=0; i<6; i++) printf(":%02x"+!i, ifre.ifr_hwaddr.sa_data[i]);
+  if (FLAG(S))
+    for (i=0; i<6; i++) printf(&":%02x"[!i], ifre.ifr_hwaddr.sa_data[i]);
   else {
     for (i=0; i < ARRAY_LEN(types)-1; i++)
       if (ifre.ifr_hwaddr.sa_family == types[i].type) break;
     xprintf("%-9s Link encap:%s  ", name, types[i].title);
     if(ifre.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
       xprintf("HWaddr ");
-      for (i=0; i<6; i++) xprintf(":%02x"+!i, ifre.ifr_hwaddr.sa_data[i]);
+      for (i=0; i<6; i++) xprintf(&":%02x"[!i], ifre.ifr_hwaddr.sa_data[i]);
     }
     sprintf(toybuf, "/sys/class/net/%.15s/device/driver", name);
     if (readlink0(toybuf, toybuf, sizeof(toybuf))>0)
@@ -161,7 +161,7 @@ static void display_ifconfig(char *name, int always, unsigned long long val[])
   pp = (char *)&ifre.ifr_addr;
   for (i = 0; i<sizeof(ifre.ifr_addr); i++) if (pp[i]) break;
 
-  if (!(toys.optflags&FLAG_S) && i != sizeof(ifre.ifr_addr)) {
+  if (!FLAG(S) && i != sizeof(ifre.ifr_addr)) {
     struct sockaddr_in *si = (struct sockaddr_in *)&ifre.ifr_addr;
     struct {
       char *name;
@@ -221,7 +221,7 @@ static void display_ifconfig(char *name, int always, unsigned long long val[])
 
             for (i=0; i<ARRAY_LEN(scopes); i++)
               if (iscope == (!!i)<<(i+3)) scope = scopes[i];
-            if (toys.optflags&FLAG_S) xprintf(" %s/%d@%c", toybuf, plen,*scope);
+            if (FLAG(S)) xprintf(" %s/%d@%c", toybuf, plen,*scope);
             else xprintf("%10cinet6 addr: %s/%d Scope: %s\n",
                          ' ', toybuf, plen, scope);
           }
@@ -231,7 +231,7 @@ static void display_ifconfig(char *name, int always, unsigned long long val[])
     fclose(fp);
   }
 
-  if (toys.optflags&FLAG_S) {
+  if (FLAG(S)) {
     xputc('\n');
     return;
   }
@@ -331,7 +331,7 @@ static void show_iface(char *iface_name)
       sl->next = ifaces;
       ifaces = sl;
 
-      display_ifconfig(sl->str, toys.optflags & FLAG_a, val);
+      display_ifconfig(sl->str, FLAG(a), val);
     }
   }
   fclose(fp);
@@ -358,7 +358,7 @@ static void show_iface(char *iface_name)
       for(sl = ifaces; sl; sl = sl->next)
         if(!strcmp(sl->str, ifre->ifr_name)) break;
 
-      if(!sl) display_ifconfig(ifre->ifr_name, toys.optflags & FLAG_a, 0);
+      if(!sl) display_ifconfig(ifre->ifr_name, FLAG(a), 0);
     }
 
     free(ifcon.ifc_buf);

--- a/toys/other/blkid.c
+++ b/toys/other/blkid.c
@@ -176,7 +176,7 @@ static void do_blkid(int fd, char *name)
                      toybuf[uoff+1], toybuf[uoff]);
     } else {
       for (j = 0; j < 16; j++)
-        s += sprintf(s, "-%02x"+!(0x550 & (1<<j)), toybuf[uoff+j]);
+        s += sprintf(s, &"-%02x"[!(0x550 & (1<<j))], toybuf[uoff+j]);
     }
 
     if (FLAG(U)) return flagshow(buf, name);

--- a/toys/other/factor.c
+++ b/toys/other/factor.c
@@ -37,7 +37,7 @@ static void factor(char *s)
       continue;
     }
 
-    printf("-%llu:"+!dash, l);
+    printf(&"-%llu:"[!dash], l);
 
     // Negative numbers have -1 as a factor
     if (dash) printf(" -1");

--- a/toys/other/fmt.c
+++ b/toys/other/fmt.c
@@ -81,7 +81,7 @@ static void fmt_line(char **pline, long len)
       TT.pos = TT.level;
       if (indent) printf("%.*s", indent, line);
     } else count++;
-    printf(" %s"+!(TT.pos!=TT.level), word);
+    printf(&" %s"[!(TT.pos!=TT.level)], word);
     TT.pos += count;
     while (isspace(line[idx])) idx++;
   }

--- a/toys/other/inotifyd.c
+++ b/toys/other/inotifyd.c
@@ -98,7 +98,7 @@ void inotifyd_main(void)
         *s = 0;
 
         if (**prog_args == '-' && !prog_args[0][1]) {
-          xprintf("%s\t%s\t%s\n" + 3*!event->len, toybuf,
+          xprintf(&"%s\t%s\t%s\n"[3*!event->len], toybuf,
               toys.optargs[event->wd], event->name);
         } else {
           prog_args[1] = toybuf;

--- a/toys/other/vmstat.c
+++ b/toys/other/vmstat.c
@@ -95,12 +95,12 @@ void vmstat_main(void)
     if (rows>3 && !(loop % (rows-3))) {
       char *header = headers;
 
-      if (!(toys.optflags&FLAG_n) && isatty(1)) terminal_size(0, &rows);
+      if (!FLAG(n) && isatty(1)) terminal_size(0, &rows);
       else rows = 0;
 
       printf("procs -----------memory---------- ---swap-- -----io---- -system-- ----cpu----\n");
       for (i=0; i<sizeof(lengths); i++) {
-        printf(" %*s"+!i, lengths[i], header);
+        printf(&" %*s"[!i], lengths[i], header);
         header += strlen(header)+1;
       }
       xputc('\n');
@@ -147,7 +147,7 @@ void vmstat_main(void)
       expected += lengths[i] + !!i;
       len = expected - offset - !!i;
       if (len < 0) len = 0;
-      offset += printf(" %*"PRIu64+!i, len, out);
+      offset += printf(&" %*"PRIu64[!i], len, out);
     }
     xputc('\n');
 

--- a/toys/pending/dumpleases.c
+++ b/toys/pending/dumpleases.c
@@ -26,7 +26,7 @@ GLOBALS(
 )
 
 //lease structure
-struct lease { 
+struct lease {
   uint32_t expires;
   uint32_t lease_nip;
   uint8_t lease_mac[6];
@@ -39,20 +39,20 @@ void dumpleases_main(void)
   struct in_addr addr;
   struct lease lease_struct;
   int64_t written_time , current_time, exp;
-  int i, fd; 
-  
-  if(!(toys.optflags & FLAG_f)) TT.file = "/var/lib/misc/dhcpd.leases"; //DEF_LEASE_FILE
+  int i, fd;
+
+  if(!FLAG(f)) TT.file = "/var/lib/misc/dhcpd.leases"; //DEF_LEASE_FILE
   fd = xopenro(TT.file);
-  xprintf("Mac Address       IP Address      Host Name           Expires %s\n", (toys.optflags & FLAG_a) ? "at" : "in");
+  xprintf("Mac Address       IP Address      Host Name           Expires %s\n", FLAG(a) ? "at" : "in");
   xread(fd, &written_time, sizeof(written_time));
   current_time = time(NULL);
   written_time = SWAP_BE64(written_time);
   if(current_time < written_time) written_time = current_time;
 
-  while(sizeof(lease_struct) == 
+  while(sizeof(lease_struct) ==
       (readall(fd, &lease_struct, sizeof(lease_struct)))) {
-    for (i = 0; i < 6; i++) printf(":%02x"+ !i, lease_struct.lease_mac[i]);
-    
+    for (i = 0; i < 6; i++) printf(&":%02x"[!i], lease_struct.lease_mac[i]);
+
     addr.s_addr = lease_struct.lease_nip;
     lease_struct.hostname[19] = '\0';
     xprintf(" %-16s%-20s", inet_ntoa(addr), lease_struct.hostname );
@@ -61,7 +61,7 @@ void dumpleases_main(void)
       xputs("expired");
       continue;
     }
-    if (!(toys.optflags & FLAG_a)) { 
+    if (!FLAG(a)) {
       unsigned dt, hr, m;
       unsigned expires = exp - current_time;
       dt = expires / (24*60*60); expires %= (24*60*60);

--- a/toys/pending/init.c
+++ b/toys/pending/init.c
@@ -211,8 +211,8 @@ static void run_command(char *command)
     final_command[x] = NULL;
   } else {
     snprintf(toybuf, sizeof(toybuf), "exec %s", command);
-    command = "-/bin/sh"+1;
-    final_command[0] = ("-/bin/sh"+!hyphen);
+    command = &"-/bin/sh"[1];
+    final_command[0] = (&"-/bin/sh"[!hyphen]);
     final_command[1] = "-c";
     final_command[2] = toybuf;
     final_command[3] = NULL;

--- a/toys/pending/man.c
+++ b/toys/pending/man.c
@@ -84,7 +84,7 @@ static void do_man(char **pline, long len)
 
   if (FLAG(k)) {
     if (!TT.k_done && !start(".") && !start("'") && k(strstr(*pline, "- ")))
-      printf("%-20s %s%s", TT.k, "- "+2*(TT.line!=*pline), TT.line);
+      printf("%-20s %s%s", TT.k, &"- "[2*(TT.line!=*pline)], TT.line);
     else if (!TT.k_done && start(".so") && k(basename(*pline + 4)))
       printf("%s - See %s", TT.k, TT.line);
   } else {
@@ -131,7 +131,7 @@ static int zopen(char *s)
   if ((*fds = open(s, O_RDONLY)) == -1) return -1;
   while (suf && *known && strcmp(suf, *known++));
   if (!suf || !*known) return *fds;
-  sprintf(toybuf, "%czcat"+2*(suf[1]=='g'), suf[1]);
+  sprintf(toybuf, &"%czcat"[2*(suf[1]=='g')], suf[1]);
   xpopen_both((char *[]){toybuf, s, 0}, fds);
   close(fds[0]);
   return fds[1];

--- a/toys/pending/sh.c
+++ b/toys/pending/sh.c
@@ -2537,7 +2537,7 @@ if (BUGBUG) dump_state(&scratch);
     free(new);
   }
 
-  if (prompt) error_exit("%ld:unfinished line"+4*!TT.lineno, TT.lineno);
+  if (prompt) error_exit(&"%ld:unfinished line"[4*!TT.lineno], TT.lineno);
   toys.exitval = f && ferror(f);
   clearerr(stdout);
 }

--- a/toys/posix/ls.c
+++ b/toys/posix/ls.c
@@ -392,7 +392,7 @@ static void listfiles(int dirfd, struct dirtree *indir)
         xputc('\n');
         width = 0;
       } else {
-        printf("  "+mm, 0); // shut up the stupid compiler
+        printf(&"  "[mm], 0); // shut up the stupid compiler
         width += 2-mm;
       }
     }
@@ -429,7 +429,7 @@ static void listfiles(int dirfd, struct dirtree *indir)
                            crunch_qb);
       }
     }
-    if (FLAG(Z)) printf(" %-*s "+!FLAG(l), -(int)totals[7], (char *)dt->extra);
+    if (FLAG(Z)) printf(&" %-*s "[!FLAG(l)], -(int)totals[7], (char *)dt->extra);
 
     if (FLAG(l)||FLAG(o)||FLAG(n)||FLAG(g)) {
       struct tm *tm;

--- a/toys/posix/ps.c
+++ b/toys/posix/ps.c
@@ -426,7 +426,7 @@ static void help_fields(int len, int multi)
       else j--;
     } else if (!multi) {
       left = !(j&1);
-      printf("  %-8s%*s%c"+2*!left, t->name, -30*left, t->help, 10+22*left);
+      printf(&"  %-8s%*s%c"[2*!left], t->name, -30*left, t->help, 10+22*left);
     }
   }
   if (!multi && left) xputc('\n');
@@ -1127,7 +1127,7 @@ static long long get_headers(struct ofields *field, char *buf, int blen)
   int len = 0;
 
   for (; field; field = field->next) {
-    len += snprintf(buf+len, blen-len, " %*s"+!bits, field->len,
+    len += snprintf(buf+len, blen-len, &" %*s"[!bits], field->len,
       field->title);
     bits |= 1LL<<field->which;
   }
@@ -1792,7 +1792,7 @@ static int iotop_filter(long long *oslot, long long *nslot, int milis)
 
 void iotop_main(void)
 {
-  char *s1 = 0, *s2 = 0, *d = "D"+!!FLAG(A);
+  char *s1 = 0, *s2 = 0, *d = &"D"[!!FLAG(A)];
 
   if (FLAG(K)) TT.forcek++;
 
@@ -1895,8 +1895,8 @@ void pgrep_main(void)
   comma_args(TT.pgrep.U, &TT.UU, "bad -U", parse_rest);
   comma_args(TT.pgrep.u, &TT.uu, "bad -u", parse_rest);
 
-  if ((toys.optflags&(FLAG_x|FLAG_f)) ||
-      !(toys.optflags&(FLAG_G|FLAG_g|FLAG_P|FLAG_s|FLAG_t|FLAG_U|FLAG_u)))
+  if ((FLAG(x) || FLAG(f)) ||
+      !(FLAG(G) || FLAG(g) || FLAG(P) || FLAG(s) || FLAG(t) || FLAG(U) || FLAG(u)))
     if (!toys.optc) help_exit("No PATTERN");
 
   if (FLAG(f)) TT.bits |= _PS_CMDLINE;

--- a/toys/posix/wc.c
+++ b/toys/posix/wc.c
@@ -47,7 +47,7 @@ static void show_lengths(unsigned long *lengths, char *name)
 
   for (i = 0; i<4; i++) {
     if (toys.optflags&(1<<i)) {
-      printf(" %*ld"+first, space, lengths[i]);
+      printf(&" %*ld"[first], space, lengths[i]);
       first = 0;
     }
     TT.totals[i] += lengths[i];


### PR DESCRIPTION
I get that this warning is dumb so I understand if it gets rejected, I just figured it might be preferable to not have to disable it (especially if it happens to eventually catch an actual issue).