### PR TITLE
Tackle SIGEMT and SIGSTKFLT is not glibc specific

### DIFF
--- a/lib/portability.c
+++ b/lib/portability.c
@@ -430,8 +430,11 @@ static const struct signame signames[] = {
   // Non-POSIX signals that cause termination
   SIGNIFY(PROF), SIGNIFY(IO),
 #ifdef __linux__
-# if !defined(__GLIBC__) && !defined(__mips__)
+# ifdef SIGSTKFLT
    SIGNIFY(STKFLT),
+# endif
+# ifdef SIGEMT
+   SIGNIFY(EMT),
 # endif
   SIGNIFY(POLL), SIGNIFY(PWR),
 #elif defined(__APPLE__)


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>