### PR TITLE
Replace [gs]ettimeofday with clock_[gs]ettime

### DIFF
--- a/toys/pending/dd.c
+++ b/toys/pending/dd.c
@@ -50,7 +50,7 @@ config DD
 GLOBALS(
   int show_xfer, show_records;
   unsigned long long bytes, c_count, in_full, in_part, out_full, out_part;
-  struct timeval start;
+  struct timespec start;
   struct {
     char *name;
     int fd;
@@ -80,11 +80,11 @@ static const struct dd_flag dd_oflag[] = TAGGED_ARRAY(DD_oflag,
 static void status()
 {
   double seconds;
-  struct timeval now;
+  struct timespec now;
 
-  gettimeofday(&now, NULL);
-  seconds = ((now.tv_sec * 1000000 + now.tv_usec) -
-      (TT.start.tv_sec * 1000000 + TT.start.tv_usec))/1000000.0;
+  clock_gettime(CLOCK_REALTIME, &now);
+  seconds = ((now.tv_sec * 1000000000 + now.tv_nsec) -
+      (TT.start.tv_sec * 1000000000 + TT.start.tv_nsec))/1000000000.0;
 
   if (TT.show_records)
     fprintf(stderr, "%llu+%llu records in\n%llu+%llu records out\n",
@@ -176,7 +176,7 @@ void dd_main()
 
   signal(SIGINT, dd_sigint);
   signal(SIGUSR1, generic_signal);
-  gettimeofday(&TT.start, NULL);
+  clock_gettime(CLOCK_REALTIME, &TT.start);
 
   // For bs=, in/out is done as it is. so only in.sz is enough.
   // With Single buffer there will be overflow in a read following partial read.

--- a/toys/posix/date.c
+++ b/toys/posix/date.c
@@ -155,12 +155,12 @@ void date_main(void)
 
   // Set the date
   } else if (setdate) {
-    struct timeval tv;
+    struct timespec tv;
 
     parse_date(setdate, &t);
     tv.tv_sec = t;
-    tv.tv_usec = TT.nano/1000;
-    if (settimeofday(&tv, NULL) < 0) perror_msg("cannot set date");
+    tv.tv_nsec = TT.nano;
+    if (clock_settime(CLOCK_REALTIME, &tv) < 0) perror_msg("cannot set date");
   }
 
   puts_time(format_string, localtime(&t));

--- a/toys/posix/time.c
+++ b/toys/posix/time.c
@@ -27,9 +27,9 @@ config TIME
 void time_main(void)
 {
   pid_t pid;
-  struct timeval tv, tv2;
+  struct timespec tv, tv2;
 
-  gettimeofday(&tv, NULL);
+  clock_gettime(CLOCK_REALTIME, &tv);
   if (!(pid = XVFORK())) xexec(toys.optargs);
   else {
     int stat;
@@ -37,12 +37,12 @@ void time_main(void)
     float r, u, s;
 
     wait4(pid, &stat, 0, &ru);
-    gettimeofday(&tv2, NULL);
-    if (tv.tv_usec > tv2.tv_usec) {
-      tv2.tv_usec += 1000000;
+    clock_gettime(CLOCK_REALTIME, &tv2);
+    if (tv.tv_nsec > tv2.tv_nsec) {
+      tv2.tv_nsec += 1000000000;
       tv2.tv_sec--;
     }
-    r = (tv2.tv_sec-tv.tv_sec)+((tv2.tv_usec-tv.tv_usec)/1000000.0);
+    r = (tv2.tv_sec-tv.tv_sec)+((tv2.tv_nsec-tv.tv_nsec)/1000000000.0);
     u = ru.ru_utime.tv_sec+(ru.ru_utime.tv_usec/1000000.0);
     s = ru.ru_stime.tv_sec+(ru.ru_stime.tv_usec/1000000.0);
     if (FLAG(v)) fprintf(stderr, "Real time (s): %f\nSystem time (s): %f\n"


### PR DESCRIPTION
gettimeofday is XSI, not POSIX, and is marked obsolete, while settimeofday is non-standard. Switch use of these functions to their modern replacements. 