### PR TITLE
dhcpd: fix warnings

### DIFF
--- a/toys/pending/dhcpd.c
+++ b/toys/pending/dhcpd.c
@@ -1287,7 +1287,7 @@ static uint32_t get_lease(uint32_t req_exp)
         req_exp > gconfig.valid_lifetime) {
       if ((gconfig.pref_lifetime > gconfig.valid_lifetime)) {
         error_msg("The valid lifetime must be greater than the preferred lifetime, \
-            setting to valid lifetime", gconfig.valid_lifetime);
+            setting to valid lifetime %"PRIu32, gconfig.valid_lifetime);
         return gconfig.valid_lifetime;
       }
       return gconfig.pref_lifetime;
@@ -1748,8 +1748,7 @@ void dhcpd_main(void)
           dbg("no or bad message type option, ignoring packet.\n");
           continue;
         }
-        if (!gstate.rcvd.rcvd_pkt6.transaction_id || 
-            memcmp(gstate.rcvd.rcvd_pkt6.transaction_id, transactionid, 3)) {
+        if (memcmp(gstate.rcvd.rcvd_pkt6.transaction_id, transactionid, 3)) {
           dbg("no or bad transaction id, ignoring packet.\n");
           continue;
         }


### PR DESCRIPTION
Add presumably intended conversion specifier for gconfig.valid_lifetime
as it is an argument to error_msg despite the format string having no
conversion specifiers.
Remove always true false inverse check for address of array
gstate.rcvd.rcvd_pkt6.transaction_id.