### PR TITLE
Remove semicolon following GLOBALS macro in the few commands that had one, as well as unneeded semicolons following one line cp functions

### DIFF
--- a/toys/net/netstat.c
+++ b/toys/net/netstat.c
@@ -34,7 +34,7 @@ config NETSTAT
 GLOBALS(
   struct num_cache *inodes;
   int wpad;
-);
+)
 
 // convert address into text format.
 static void addr2str(int af, void *addr, unsigned port, char *buf, int len,

--- a/toys/pending/dd.c
+++ b/toys/pending/dd.c
@@ -59,7 +59,7 @@ GLOBALS(
     unsigned long long offset;
   } in, out;
   unsigned conv, iflag, oflag;
-);
+)
 
 struct dd_flag {
   char *name;

--- a/toys/pending/dhcpd.c
+++ b/toys/pending/dhcpd.c
@@ -125,7 +125,7 @@ config DEBUG_DHCP
 GLOBALS(
     char *iface;
     long port;
-);
+)
 
 struct config_keyword {
   char *keyword;

--- a/toys/posix/cp.c
+++ b/toys/posix/cp.c
@@ -463,9 +463,9 @@ void mv_main(void)
 
 // Export cp flags into install's flag context.
 
-static inline int cp_flag_F(void) { return FLAG_F; };
-static inline int cp_flag_p(void) { return FLAG_p; };
-static inline int cp_flag_v(void) { return FLAG_v; };
+static inline int cp_flag_F(void) { return FLAG_F; }
+static inline int cp_flag_p(void) { return FLAG_p; }
+static inline int cp_flag_v(void) { return FLAG_v; }
 
 // Switch to install's flag context
 #define CLEANUP_cp

--- a/toys/posix/env.c
+++ b/toys/posix/env.c
@@ -26,7 +26,7 @@ config ENV
 
 GLOBALS(
   struct arg_list *u;
-);
+)
 
 void env_main(void)
 {


### PR DESCRIPTION
These cause a -Wextra-semi (if it is enabled) warning for every inclusion of globals.h, due to a double-semicolon following the structs for these commands' global variables. Remove the unnecessary semicolons.