### PR TITLE
Remove anonymous unions

### DIFF
--- a/toys/example/skeleton.c
+++ b/toys/example/skeleton.c
@@ -55,7 +55,7 @@ GLOBALS(
     struct {
       long b;
     } a;
-  };
+  } u;
 
   int more_globals;
 )
@@ -74,17 +74,17 @@ void skeleton_main(void)
   // from main.c using the optstring in the NEWTOY macros. Display results.
   if (toys.optflags) printf("flags=%llx\n", toys.optflags);
   if (FLAG(a)) printf("Saw a\n");
-  if (FLAG(b)) printf("b=%s\n", TT.s.b);
-  if (FLAG(c)) printf("c=%ld\n", TT.s.c);
-  while (TT.s.d) {
-    printf("d=%s\n", TT.s.d->arg);
-    TT.s.d = TT.s.d->next;
+  if (FLAG(b)) printf("b=%s\n", TT.u.s.b);
+  if (FLAG(c)) printf("c=%ld\n", TT.u.s.c);
+  while (TT.u.s.d) {
+    printf("d=%s\n", TT.u.s.d->arg);
+    TT.u.s.d = TT.u.s.d->next;
   }
-  if (TT.s.e) printf("e was seen %ld times\n", TT.s.e);
+  if (TT.u.s.e) printf("e was seen %ld times\n", TT.u.s.e);
   for (optargs = toys.optargs; *optargs; optargs++)
     printf("optarg=%s\n", *optargs);
   if (FLAG(walrus)) printf("Saw --walrus\n");
-  if (TT.s.blubber) printf("--blubber=%s\n", TT.s.blubber);
+  if (TT.u.s.blubber) printf("--blubber=%s\n", TT.u.s.blubber);
 
   printf("Other globals should start zeroed: %d\n", TT.more_globals);
 }
@@ -101,5 +101,5 @@ void skeleton_alias_main(void)
 
   // Note, this FLAG_b is a different bit position than the other FLAG_b,
   // and fills out a different variable of a different type.
-  if (FLAG(b)) printf("b=%ld", TT.a.b);
+  if (FLAG(b)) printf("b=%ld", TT.u.a.b);
 }

--- a/toys/pending/sh.c
+++ b/toys/pending/sh.c
@@ -165,7 +165,7 @@ GLOBALS(
     struct {
       char *a;
     } exec;
-  };
+  } u;
 
   // keep lineno here, we use it to work around a compiler bug
   long lineno;
@@ -2525,7 +2525,7 @@ static void subshell_setup(void)
 
 void sh_main(void)
 {
-  char *new, *cc = TT.sh.c;
+  char *new, *cc = TT.u.sh.c;
   struct sh_function scratch;
   int prompt = 0;
   struct string_list *sl = 0;
@@ -2775,8 +2775,9 @@ void exec_main(void)
   // exec, handling -acl
   TT.isexec = *toys.optargs;
   if (FLAG(c)) environ = ee;
-  if (TT.exec.a || FLAG(l))
-    *toys.optargs = xmprintf("%s%s", FLAG(l) ? "-" : "", TT.exec.a?:TT.isexec);
+  if (TT.u.exec.a || FLAG(l))
+    *toys.optargs = xmprintf("%s%s", FLAG(l) ? "-" : "",
+      TT.u.exec.a?:TT.isexec);
   sh_exec(toys.optargs);
 
   // report error (usually ENOENT) and return

--- a/toys/posix/cp.c
+++ b/toys/posix/cp.c
@@ -99,7 +99,7 @@ GLOBALS(
     struct {
       char *preserve;
     } c;
-  };
+  } u;
 
   char *destname;
   struct stat top;
@@ -374,7 +374,7 @@ void cp_main(void)
 
   // Not using comma_args() (yet?) because interpeting as letters.
   if (FLAG(preserve)) {
-    char *pre = xstrdup(TT.c.preserve ? TT.c.preserve : "mot"), *s;
+    char *pre = xstrdup(TT.u.c.preserve ? TT.u.c.preserve : "mot"), *s;
 
     if (comma_remove(pre, "all")) TT.pflags = ~0;
     for (i=0; i<ARRAY_LEN(cp_preserve); i++)
@@ -474,9 +474,9 @@ static inline int cp_flag_v(void) { return FLAG_v; };
 
 static int install_node(struct dirtree *try)
 {
-  try->st.st_mode = TT.i.m ? string_to_mode(TT.i.m, try->st.st_mode) : 0755;
-  if (TT.i.g) try->st.st_gid = TT.gid;
-  if (TT.i.o) try->st.st_uid = TT.uid;
+  try->st.st_mode = TT.u.i.m ? string_to_mode(TT.u.i.m, try->st.st_mode) : 0755;
+  if (TT.u.i.g) try->st.st_gid = TT.gid;
+  if (TT.u.i.o) try->st.st_uid = TT.uid;
 
   // Always returns 0 because no -r
   cp_node(try);
@@ -492,8 +492,8 @@ void install_main(void)
 {
   char **ss;
 
-  TT.uid = TT.i.o ? xgetuid(TT.i.o) : -1;
-  TT.gid = TT.i.g ? xgetgid(TT.i.g) : -1;
+  TT.uid = TT.u.i.o ? xgetuid(TT.u.i.o) : -1;
+  TT.gid = TT.u.i.g ? xgetgid(TT.u.i.g) : -1;
 
   if (FLAG(d)) {
     for (ss = toys.optargs; *ss; ss++) {

--- a/toys/posix/ps.c
+++ b/toys/posix/ps.c
@@ -205,7 +205,7 @@ GLOBALS(
       int signal;
       pid_t self, match;
     } pgrep;
-  };
+  } u;
 
   struct ptr_len gg, GG, pp, PP, ss, tt, uu, UU;
   struct dirtree *threadparent;
@@ -1301,15 +1301,15 @@ void ps_main(void)
   if (FLAG(w)) TT.width = 99999;
 
   // parse command line options other than -o
-  comma_args(TT.ps.P, &TT.PP, "bad -P", parse_rest);
-  comma_args(TT.ps.p, &TT.pp, "bad -p", parse_rest);
-  comma_args(TT.ps.t, &TT.tt, "bad -t", parse_rest);
-  comma_args(TT.ps.s, &TT.ss, "bad -s", parse_rest);
-  comma_args(TT.ps.u, &TT.uu, "bad -u", parse_rest);
-  comma_args(TT.ps.U, &TT.UU, "bad -U", parse_rest);
-  comma_args(TT.ps.g, &TT.gg, "bad -g", parse_rest);
-  comma_args(TT.ps.G, &TT.GG, "bad -G", parse_rest);
-  comma_args(TT.ps.k, &TT.kfields, "bad -k", parse_ko);
+  comma_args(TT.u.ps.P, &TT.PP, "bad -P", parse_rest);
+  comma_args(TT.u.ps.p, &TT.pp, "bad -p", parse_rest);
+  comma_args(TT.u.ps.t, &TT.tt, "bad -t", parse_rest);
+  comma_args(TT.u.ps.s, &TT.ss, "bad -s", parse_rest);
+  comma_args(TT.u.ps.u, &TT.uu, "bad -u", parse_rest);
+  comma_args(TT.u.ps.U, &TT.UU, "bad -U", parse_rest);
+  comma_args(TT.u.ps.g, &TT.gg, "bad -g", parse_rest);
+  comma_args(TT.u.ps.G, &TT.GG, "bad -G", parse_rest);
+  comma_args(TT.u.ps.k, &TT.kfields, "bad -k", parse_ko);
   dlist_terminate(TT.kfields);
 
   // It's undocumented, but traditionally extra arguments are extra -p args
@@ -1329,13 +1329,13 @@ void ps_main(void)
             FLAG(T) ? "CMD" : "NAME");
   sprintf(toybuf, not_o, FLAG(T) ? "PID,TID," : "PID,");
 
-  // Init TT.fields. This only uses toybuf if TT.ps.o is NULL
+  // Init TT.fields. This only uses toybuf if TT.u.ps.o is NULL
   if (FLAG(Z)) default_ko("LABEL", &TT.fields, 0, 0);
-  default_ko(toybuf, &TT.fields, "bad -o", TT.ps.o);
+  default_ko(toybuf, &TT.fields, "bad -o", TT.u.ps.o);
 
-  if (TT.ps.O) {
+  if (TT.u.ps.O) {
     if (TT.fields) TT.fields = ((struct ofields *)TT.fields)->prev;
-    comma_args(TT.ps.O, &TT.fields, "bad -O", parse_ko);
+    comma_args(TT.u.ps.O, &TT.fields, "bad -O", parse_ko);
     if (TT.fields) TT.fields = ((struct ofields *)TT.fields)->next;
   }
   dlist_terminate(TT.fields);
@@ -1558,7 +1558,7 @@ static void top_common(
             terminal_probesize(&TT.width, &TT.height);
           }
         }
-        if (TT.top.m) TT.height = TT.top.m+5;
+        if (TT.u.top.m) TT.height = TT.u.top.m+5;
         lines = TT.height;
       }
       if (recalc && !FLAG(q)) {
@@ -1672,14 +1672,14 @@ static void top_common(
         if (bold) printf("\033[m");
       }
 
-      if (TT.top.n && !--TT.top.n) {
+      if (TT.u.top.n && !--TT.u.top.n) {
         done++;
         break;
       }
 
       now = millitime();
-      if (timeout<=now) timeout = new.whence+TT.top.d;
-      if (timeout<=now || timeout>now+TT.top.d) timeout = now+TT.top.d;
+      if (timeout<=now) timeout = new.whence+TT.u.top.d;
+      if (timeout<=now || timeout>now+TT.u.top.d) timeout = now+TT.u.top.d;
 
       // In batch mode, we ignore the keyboard.
       if (FLAG(b)) {
@@ -1745,32 +1745,32 @@ static void top_setup(char *defo, char *defk)
     start_redraw(&TT.width, &TT.height);
   }
 
-  comma_args(TT.top.u, &TT.uu, "bad -u", parse_rest);
-  comma_args(TT.top.p, &TT.pp, "bad -p", parse_rest);
+  comma_args(TT.u.top.u, &TT.uu, "bad -u", parse_rest);
+  comma_args(TT.u.top.p, &TT.pp, "bad -p", parse_rest);
   TT.match_process = shared_match_process;
 
-  default_ko(defo, &TT.fields, "bad -o", TT.top.o);
+  default_ko(defo, &TT.fields, "bad -o", TT.u.top.o);
   dlist_terminate(TT.fields);
 
   // First (dummy) sort field is overwritten by setsort()
   default_ko("-S", &TT.kfields, 0, 0);
-  default_ko(defk, &TT.kfields, "bad -k", TT.top.k);
+  default_ko(defk, &TT.kfields, "bad -k", TT.u.top.k);
   dlist_terminate(TT.kfields);
-  setsort(TT.top.s-1);
+  setsort(TT.u.top.s-1);
 }
 
 void top_main(void)
 {
   sprintf(toybuf, "%cID,USER,%s%%CPU,%%MEM,TIME+,%s", FLAG(H) ? 'T' : 'P',
-    TT.top.O ? "" : "PR,NI,VIRT,RES,SHR,S,",
+    TT.u.top.O ? "" : "PR,NI,VIRT,RES,SHR,S,",
     FLAG(H) ? "CMD:15=THREAD,NAME=PROCESS" : "ARGS");
-  if (!TT.top.s) TT.top.s = TT.top.O ? 3 : 9;
+  if (!TT.u.top.s) TT.u.top.s = TT.u.top.O ? 3 : 9;
   top_setup(toybuf, "-%CPU,-ETIME,-PID");
-  if (TT.top.O) {
+  if (TT.u.top.O) {
     struct ofields *field = TT.fields;
 
     field = field->next->next;
-    comma_args(TT.top.O, &field, "bad -O", parse_ko);
+    comma_args(TT.u.top.O, &field, "bad -O", parse_ko);
   }
 
   top_common(merge_deltas);
@@ -1818,20 +1818,20 @@ struct regex_list {
 
 static void do_pgk(struct procpid *tb)
 {
-  if (TT.pgrep.signal) {
-    if (kill(*tb->slot, TT.pgrep.signal)) {
-      char *s = num_to_sig(TT.pgrep.signal);
+  if (TT.u.pgrep.signal) {
+    if (kill(*tb->slot, TT.u.pgrep.signal)) {
+      char *s = num_to_sig(TT.u.pgrep.signal);
 
-      if (!s) sprintf(s = toybuf, "%d", TT.pgrep.signal);
+      if (!s) sprintf(s = toybuf, "%d", TT.u.pgrep.signal);
       perror_msg("%s->%lld", s, *tb->slot);
     }
   }
-  if (!FLAG(c) && (!TT.pgrep.signal || TT.tty)) {
+  if (!FLAG(c) && (!TT.u.pgrep.signal || TT.tty)) {
     printf("%lld", *tb->slot);
     if (FLAG(l))
       printf(" %s", tb->str+tb->offset[4]*!!FLAG(f));
     
-    printf("%s", TT.pgrep.d ? TT.pgrep.d : "\n");
+    printf("%s", TT.u.pgrep.d ? TT.u.pgrep.d : "\n");
   }
 }
 
@@ -1843,10 +1843,10 @@ static void match_pgrep(void *p)
   char *name = tb->str+tb->offset[4]*!!FLAG(f);
 
   // Never match ourselves.
-  if (TT.pgrep.self == *tb->slot) return;
+  if (TT.u.pgrep.self == *tb->slot) return;
 
-  if (TT.pgrep.regexes) {
-    for (reg = TT.pgrep.regexes; reg; reg = reg->next) {
+  if (TT.u.pgrep.regexes) {
+    for (reg = TT.u.pgrep.regexes; reg; reg = reg->next) {
       if (regexec(&reg->reg, name, 1, &match, 0)) continue;
       if (FLAG(x))
         if (match.rm_so || match.rm_eo!=strlen(name)) continue;
@@ -1866,8 +1866,8 @@ static void match_pgrep(void *p)
     if (FLAG(o)) ll *= -1;
     if (TT.time && TT.time>ll) return;
     TT.time = ll;
-    free(TT.pgrep.snapshot);
-    TT.pgrep.snapshot = xmemdup(toybuf, (name+strlen(name)+1)-toybuf);
+    free(TT.u.pgrep.snapshot);
+    TT.u.pgrep.snapshot = xmemdup(toybuf, (name+strlen(name)+1)-toybuf);
   } else do_pgk(tb);
 }
 
@@ -1881,19 +1881,19 @@ void pgrep_main(void)
   char **arg;
   struct regex_list *reg;
 
-  TT.pgrep.self = getpid();
+  TT.u.pgrep.self = getpid();
 
   // No signal names start with "L", so no need for "L: " in optstr.
-  if (TT.pgrep.L && 1>(TT.pgrep.signal = sig_to_num(TT.pgrep.L)))
-    error_exit("bad -L '%s'", TT.pgrep.L);
+  if (TT.u.pgrep.L && 1>(TT.u.pgrep.signal = sig_to_num(TT.u.pgrep.L)))
+    error_exit("bad -L '%s'", TT.u.pgrep.L);
 
-  comma_args(TT.pgrep.G, &TT.GG, "bad -G", parse_rest);
-  comma_args(TT.pgrep.g, &TT.gg, "bad -g", parse_rest);
-  comma_args(TT.pgrep.P, &TT.PP, "bad -P", parse_rest);
-  comma_args(TT.pgrep.s, &TT.ss, "bad -s", parse_rest);
-  comma_args(TT.pgrep.t, &TT.tt, "bad -t", parse_rest);
-  comma_args(TT.pgrep.U, &TT.UU, "bad -U", parse_rest);
-  comma_args(TT.pgrep.u, &TT.uu, "bad -u", parse_rest);
+  comma_args(TT.u.pgrep.G, &TT.GG, "bad -G", parse_rest);
+  comma_args(TT.u.pgrep.g, &TT.gg, "bad -g", parse_rest);
+  comma_args(TT.u.pgrep.P, &TT.PP, "bad -P", parse_rest);
+  comma_args(TT.u.pgrep.s, &TT.ss, "bad -s", parse_rest);
+  comma_args(TT.u.pgrep.t, &TT.tt, "bad -t", parse_rest);
+  comma_args(TT.u.pgrep.U, &TT.UU, "bad -U", parse_rest);
+  comma_args(TT.u.pgrep.u, &TT.uu, "bad -u", parse_rest);
 
   if ((toys.optflags&(FLAG_x|FLAG_f)) ||
       !(toys.optflags&(FLAG_G|FLAG_g|FLAG_P|FLAG_s|FLAG_t|FLAG_U|FLAG_u)))
@@ -1903,8 +1903,8 @@ void pgrep_main(void)
   for (arg = toys.optargs; *arg; arg++) {
     reg = xmalloc(sizeof(struct regex_list));
     xregcomp(&reg->reg, *arg, REG_EXTENDED);
-    reg->next = TT.pgrep.regexes;
-    TT.pgrep.regexes = reg;
+    reg->next = TT.u.pgrep.regexes;
+    TT.u.pgrep.regexes = reg;
   }
   TT.match_process = pgrep_match_process;
   TT.show_process = match_pgrep;
@@ -1914,11 +1914,11 @@ void pgrep_main(void)
 
   dirtree_flagread("/proc", DIRTREE_SHUTUP|DIRTREE_PROC, get_ps);
   if (FLAG(c)) printf("%d\n", TT.sortpos);
-  if (TT.pgrep.snapshot) {
-    do_pgk(TT.pgrep.snapshot);
-    if (CFG_TOYBOX_FREE) free(TT.pgrep.snapshot);
+  if (TT.u.pgrep.snapshot) {
+    do_pgk(TT.u.pgrep.snapshot);
+    if (CFG_TOYBOX_FREE) free(TT.u.pgrep.snapshot);
   }
-  if (TT.pgrep.d) xputc('\n');
+  if (TT.u.pgrep.d) xputc('\n');
 }
 
 #define CLEANUP_pgrep
@@ -1929,8 +1929,8 @@ void pkill_main(void)
 {
   char **args = toys.optargs;
 
-  if (!FLAG(l) && *args && **args=='-') TT.pgrep.L = *(args++)+1;
-  if (!TT.pgrep.L) TT.pgrep.signal = SIGTERM;
+  if (!FLAG(l) && *args && **args=='-') TT.u.pgrep.L = *(args++)+1;
+  if (!TT.u.pgrep.L) TT.u.pgrep.signal = SIGTERM;
   if (FLAG(V)) TT.tty = 1;
   pgrep_main();
 }


### PR DESCRIPTION
These are either GNU extensions to c99/c11, the toybox design page says it's supposed to be c99, so name previously anonymous unions "u".