### PR TITLE
Add missing longopts alias for chgrp/chown and rmdir

### DIFF
--- a/toys/posix/chgrp.c
+++ b/toys/posix/chgrp.c
@@ -5,7 +5,7 @@
  * See http://opengroup.org/onlinepubs/9699919799/utilities/chown.html
  * See http://opengroup.org/onlinepubs/9699919799/utilities/chgrp.html
 
-USE_CHGRP(NEWTOY(chgrp, "<2hPLHRfv[-HLP]", TOYFLAG_BIN))
+USE_CHGRP(NEWTOY(chgrp, "<2h(no-dereference)PLHRfv[-HLP]", TOYFLAG_BIN))
 USE_CHOWN(OLDTOY(chown, chgrp, TOYFLAG_BIN))
 
 config CHGRP

--- a/toys/posix/rmdir.c
+++ b/toys/posix/rmdir.c
@@ -4,7 +4,7 @@
  *
  * See http://opengroup.org/onlinepubs/9699919799/utilities/rmdir.html
 
-USE_RMDIR(NEWTOY(rmdir, "<1(ignore-fail-on-non-empty)p", TOYFLAG_BIN))
+USE_RMDIR(NEWTOY(rmdir, "<1(ignore-fail-on-non-empty)p(parents)", TOYFLAG_BIN))
 
 config RMDIR
   bool "rmdir"


### PR DESCRIPTION
Heavily used long params under some contexts for already implemented
options:

 chgrp/chown:
  Add alias '--no-dereference' for '-h'

 rmdir:
  Add alias '--parents' for '-p'

-- 

Please, take those links as lists of current usages for both longopts and consider merging:
  https://codesearch.debian.net/search?q=chown.*--no-dereference&literal=0
  https://codesearch.debian.net/search?q=rmdir.*--parents&literal=0

Avoid adding the options to help text is the preferred way? I've seen that way in other toys (I.E. ps)

Regards,