### PR TITLE
toybox: include more web links in help text.

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -16,6 +16,9 @@ config TOYBOX
 	  usage: toybox [--long | --help | --version | [COMMAND] [ARGUMENTS...]]
 
 	  Toybox multicall binary: https://landley.net/toybox/about.html
+	  Bug reports: https://github.com/landley/toybox/issues
+	  Feedback: http://lists.landley.net/listinfo.cgi/toybox-landley.net
+	  Contributors, please see: https://landley.net/toybox/cleanup.html
 
 	  With no arguments, "toybox" shows available COMMAND names. Add --long
 	  to include suggested install path for each command, see


### PR DESCRIPTION
This commit partially fixes #50. For a more-complete fix, we'd also need to prepend at least one or two web links to the help for each individual applet.