### PR TITLE
Fix a typo

### DIFF
--- a/www/roadmap.html
+++ b/www/roadmap.html
@@ -94,7 +94,7 @@ we have to extensively filter posix to get a useful set of recommendations.</p>
 <p>Starting with the
 <a href="http://pubs.opengroup.org/onlinepubs/9699919799.2008edition/idx/utilities.html">full "utilities" list</a>,
 we first remove generally obsolete
-commands (compess ed ex pr uncompress uccp uustat uux), commands for the
+commands (compress ed ex pr uncompress uccp uustat uux), commands for the
 pre-CVS "SCCS" source control system (admin delta get prs rmdel sact sccs unget
 val what), fortran support (asa fort77), and batch processing support (batch
 qalter qdel qhold qmove qmsg qrerun qrls qselect qsig qstat qsub).</p>


### PR DESCRIPTION
Fix a small typo, should be `compress` not `compess`.