### PR TITLE
cksum and hostid are already implemented

### DIFF
--- a/www/roadmap.html
+++ b/www/roadmap.html
@@ -1167,15 +1167,15 @@ vigr vipw, grpconv grpunconv pwconv pwunconv, chgpasswd gpasswd)</li>
 <li><b>psmisc</b>: killall [fuser] [pstree] [peekfd] [prtstat]
 (not: pslog pstree.x11)</li>
 <li><b>inetutils</b>: dnsdomainname [ftp] hostname ifconfig ping ping6 [telnet] [tftp] [traceroute] (not: talk)</li>
-<li><b>coreutils</b>: [ base64 basename true cat chgrp chmod chown chroot comm cp cut date
-dd df dirname du echo env expand factor false fmt fold groups head id install
+<li><b>coreutils</b>: [ base64 basename true cat chgrp chmod chown chroot cksum comm cp cut date
+dd df dirname du echo env expand factor false fmt fold groups head hostid id install
 link ln logname ls md5sum mkdir mkfifo mknod mktemp mv nice nl nohup nproc od
 paste printenv printf pwd readlink realpath rm rmdir seq sha1sum shred
 sleep sort split stat sync tac tail tee test timeout touch true truncate
 tty uname uniq unlink wc who whoami yes
 [expr] [fold] [join] [numfmt] [runcon] [sha224sum] [sha256sum] [sha384sum]
 [sha512sum] [stty] [b2sum] [tr] [unexpand]
-(not: b2sum base32 basenc chcon cksum csplit dir dircolors hostid pathchk
+(not: b2sum base32 basenc chcon csplit dir dircolors pathchk
 pinky pr ptx shuf stdbuf sum tsort users vdir, see also libstdbuf)</li>
 <li><b>util-linux</b>: blkid blockdev cal chrt dmesg eject fallocate flock hwclock
 ionice kill logger losetup mcookie mkswap more mount mountpoint nsenter


### PR DESCRIPTION
Both of [cksum](https://github.com/landley/toybox/blob/master/toys/posix/cksum.c) and [hostid](https://github.com/landley/toybox/blob/master/toys/example/hostid.c) are already implemented, unless you're planning on removing them.