### PR TITLE
Replace $CC with cc

### DIFF
--- a/scripts/portability.sh
+++ b/scripts/portability.sh
@@ -2,9 +2,9 @@
 
 source configure
 
-if [ -z "$(command -v "${CROSS_COMPILE}${CC}")" ]
+if [ -z "$(command -v "${CROSS_COMPILE}cc")" ]
 then
-  echo "No ${CROSS_COMPILE}${CC} found" >&2
+  echo "No ${CROSS_COMPILE}cc found" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Having both `$CROSS_COMPILE` and `$CC` will cause a duplication of the target tuple (triplet or quadruplet).

This is mostly due to the fact that many cross compilation toolchains set `CROSS_COMPILE` to `$TARGET_TRIPLET-` and `CC` to `$TARGET_TRIPLET-cc`, so in the case for `scripts/portability.sh` the final path will be `$TARGET_TRIPLET-$TARGET_TRIPLET-cc` which won't be found.