### PR TITLE
Update i2ctools.c

### DIFF
--- a/toys/other/i2ctools.c
+++ b/toys/other/i2ctools.c
@@ -196,7 +196,7 @@ void i2cdetect_main(void)
     bus = atolx_range(*toys.optargs, 0, INT_MAX);
     if (toys.optc == 3) {
       first = atolx_range(toys.optargs[1], 0, 0x7f);
-      last = atolx_range(toys.optargs[1], 0, 0x7f);
+      last = atolx_range(toys.optargs[2], 0, 0x7f);
       if (first > last) error_exit("first > last");
     }
 


### PR DESCRIPTION
Fix i2cdetect parameter reading so "last" value is read from correct argument.

Both range variables, "first" and "last" are incorrectly being read from argument 1. "last" should be read from argument 2.
This patch fixes the error.