### PR TITLE
Fixed -Woverflow warning while compiling gcc-10

### DIFF
--- a/main.c
+++ b/main.c
@@ -25,7 +25,7 @@ char toybuf[4096], libbuf[4096];
 
 struct toy_list *toy_find(char *name)
 {
-  int top, bottom, middle;
+  long unsigned int top, bottom, middle;
 
   if (!CFG_TOYBOX || strchr(name, '/')) return 0;
 


### PR DESCRIPTION
In main commands source there is a -Woverflow gives me while making with `make V=1` . After this patch that issue fixed.
Bests, regards.