### PR TITLE
uname: add -p (platform) support as fixed string 'unknown'

### DIFF
--- a/toys/posix/uname.c
+++ b/toys/posix/uname.c
@@ -4,7 +4,7 @@
  *
  * See http://opengroup.org/onlinepubs/9699919799/utilities/uname.html
 
-USE_UNAME(NEWTOY(uname, "oamvrns[+os]", TOYFLAG_BIN))
+USE_UNAME(NEWTOY(uname, "poamvrns[+os]", TOYFLAG_BIN))
 USE_ARCH(NEWTOY(arch, 0, TOYFLAG_USR|TOYFLAG_BIN))
 
 config ARCH 
@@ -28,7 +28,8 @@ config UNAME
     -r	Kernel Release number
     -v	Kernel Version 
     -m	Machine (hardware) name
-    -a	All of the above
+    -p	Platform
+    -a	All of the above but platform
 */
 
 #define FOR_uname
@@ -79,6 +80,16 @@ void uname_main(void)
       }
       xwrite(1, c, len);
     }
+  }
+  if ((flags & FLAG_p) && !(flags & FLAG_a)) {
+      char *c = " unknown";
+
+      if (!needspace) {
+        c++;
+      }
+      int len = strlen(c);
+
+      xwrite(1, c, len);
   }
   putchar('\n');
 }


### PR DESCRIPTION
A kind of dummy option required by some building scripts.

I've found a common output for `uname -p` is "unknown" in Linux boxes.
I can't guarantee this is the expected output for all Toybox supported platforms.

Some usage examples here:
* https://codesearch.debian.net/search?q=uname.*-p&literal=0
* https://codesearch.debian.net/show?file=pd-beatpipe_0.1-6%2FMakefile&line=70 (Darwin example expecting `arm`?)
* https://sources.debian.org/src/filtergen/0.12.8-1/debian/patches/debian-changes/ (Usage on *BSD and other Unix platforms where expects specific strings other than `unknown`)


Hope the code follows style recommendations. It's my first chunk of code for Toybox, that's why I've chosen  to add a simple option that solves some situations on building key-packages.

Regards,