### PR TITLE
Enable building for pre-4.5 Linux

### DIFF
--- a/toys/other/lsattr.c
+++ b/toys/other/lsattr.c
@@ -102,7 +102,9 @@ static struct ext2_attr {
   {"No_Dump",                       FS_NODUMP_FL,       'd'},
   {"No_Atime",                      FS_NOATIME_FL,      'A'},
   {"Compression_Requested",         FS_COMPR_FL,        'c'},
+  #ifdef FS_ENCRYPT_FL /* Linux >= 4.5 */
   {"Encrypted",                     FS_ENCRYPT_FL,      'E'},
+  #endif
   {"Journaled_Data",                FS_JOURNAL_DATA_FL, 'j'},
   {"Indexed_directory",             FS_INDEX_FL,        'I'},
   {"No_Tailmerging",                FS_NOTAIL_FL,       't'},
@@ -110,7 +112,9 @@ static struct ext2_attr {
   {"Extents",                       FS_EXTENT_FL,       'e'},
   {"No_COW",                        FS_NOCOW_FL,        'C'},
   {"Casefold",                      FS_CASEFOLD_FL,     'F'},
+  #ifdef FS_INLINE_DATA_FL /* Linux >= 4.5 */
   {"Inline_Data",                   FS_INLINE_DATA_FL,  'N'},
+  #endif
   {"Project_Hierarchy",             FS_PROJINHERIT_FL,  'P'},
   {"Verity",                        FS_VERITY_FL,       'V'},
   {NULL,                            0,                  0},

--- a/toys/posix/getconf.c
+++ b/toys/posix/getconf.c
@@ -46,6 +46,11 @@ config GETCONF
 #define _CS_V7_ENV -1
 #endif
 
+#ifndef _CS_V7_ENV
+// _CS_V7_ENV introduced by IEEE Std 1003.1-2001
+#define _CS_V7_ENV 0
+#endif
+
 struct config {
   char *name;
   long long value;


### PR DESCRIPTION
This enables building toybox for pre 4.5 linux kernel.
If this is not something you are interested in, feel free to close out this PR — no hard feelings :-)

See https://github.com/landley/toybox/issues/254
