### PR TITLE
Add -executable & -executable-sane to find

### DIFF
--- a/toys/posix/find.c
+++ b/toys/posix/find.c
@@ -34,6 +34,9 @@ config FIND
     -depth           ignore contents of dir    -maxdepth N at most N dirs down
     -inum N          inode number N            -empty      empty files and dirs
     -type [bcdflps]  type is (block, char, dir, file, symlink, pipe, socket)
+    -executable      Matches files which are executable and directories which
+                     are searchable
+    -executable-sane Matches files which are executable
     -true            always true               -false      always false
     -context PATTERN security context
     -newerXY FILE    X=acm time > FILE's Y=acm time (Y=t: FILE is literal time)
@@ -350,7 +353,10 @@ static int do_find(struct dirtree *new)
       if (check) if (bufgetgrgid(new->st.st_gid)) test = 0;
     } else if (!strcmp(s, "prune")) {
       if (check && S_ISDIR(new->st.st_mode) && !TT.depth) recurse = 0;
-
+    } else if (!strcmp(s, "executable")) {
+      if (check) if (!(access(dirtree_path(new, 0), X_OK) == 0)) test = 0;
+    } else if (!strcmp(s, "executable-sane")) {
+      if (check) if (!S_ISREG(new->st.st_mode) || !(access(dirtree_path(new, 0), X_OK) == 0)) test = 0;
     // Remaining filters take an argument
     } else {
       if (!strcmp(s, "name") || !strcmp(s, "iname")


### PR DESCRIPTION
I know the reasoning behind -executable also returning searchable directories. 
I just think it's bad and not intuitive for newcomers, `-executable-sane` should point out the default behavior is weird. 
The text next to `-executable` explains the behavior but a user that skims that over that might still see `-executable-sane`.