### PR TITLE
Handle paths starting with slash in rmdir -p

### DIFF
--- a/toys/posix/rmdir.c
+++ b/toys/posix/rmdir.c
@@ -37,6 +37,12 @@ static void do_rmdir(char *name)
     if (!toys.optflags) return;
     do {
       if (!(temp = strrchr(name, '/'))) return;
+
+      if (temp == name) {
+        temp[1] = 0;
+        break;
+      }
+
       *temp = 0;
     } while (!temp[1]);
   }


### PR DESCRIPTION
When comparing behavior with the rmdir shipped with the linux distro I am running I have found that ```rmdir -p /a/b/c``` acts differently compared ```./toybox rmdir /a/b/c``` because of the way toybox handles the slashes, it removes them so when arriving at the first slash it actually attempts to rmdir nothing which is invalid.

This PR makes it correctly try to remove the first slash upon reaching there.