### PR TITLE
Add OpenBSD support

### DIFF
--- a/lib/portability.c
+++ b/lib/portability.c
@@ -49,7 +49,7 @@ int xgetrandom(void *buf, unsigned buflen, unsigned flags)
 // Get list of mounted filesystems, including stat and statvfs info.
 // Returns a reversed list, which is good for finding overmounts and such.
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #include <sys/mount.h>
 
@@ -188,7 +188,7 @@ struct mtab_list *xgetmountlist(char *path)
 
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 
 #include <sys/event.h>
 
@@ -332,7 +332,7 @@ ssize_t xattr_fset(int fd, const char* name,
   return fsetxattr(fd, name, value, size, 0, flags);
 }
 
-#else
+#elif !defined(__OpenBSD__)
 
 ssize_t xattr_get(const char *path, const char *name, void *value, size_t size)
 {
@@ -534,6 +534,8 @@ int dev_minor(int dev)
   return ((dev&0xfff00000)>>12)|(dev&0xff);
 #elif defined(__APPLE__)
   return dev&0xffffff;
+#elif defined(__OpenBSD__)
+  return minor(dev);
 #else
 #error
 #endif
@@ -545,6 +547,8 @@ int dev_major(int dev)
   return (dev&0xfff00)>>8;
 #elif defined(__APPLE__)
   return (dev>>24)&0xff;
+#elif defined(__OpenBSD__)
+  return major(dev);
 #else
 #error
 #endif
@@ -556,6 +560,8 @@ int dev_makedev(int major, int minor)
   return (minor&0xff)|((major&0xfff)<<8)|((minor&0xfff00)<<12);
 #elif defined(__APPLE__)
   return (minor&0xffffff)|((major&0xff)<<24);
+#elif defined(__OpenBSD__)
+  return makedev(major, minor);
 #else
 #error
 #endif
@@ -563,7 +569,7 @@ int dev_makedev(int major, int minor)
 
 char *fs_type_name(struct statfs *statfs)
 {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__OpenBSD__)
   // macOS has an `f_type` field, but assigns values dynamically as filesystems
   // are registered. They do give you the name directly though, so use that.
   return statfs->f_fstypename;
@@ -605,6 +611,16 @@ int get_block_device_size(int fd, unsigned long long* size)
 int get_block_device_size(int fd, unsigned long long* size)
 {
   return (ioctl(fd, BLKGETSIZE64, size) >= 0);
+}
+#elif defined(__OpenBSD__)
+#include <sys/dkio.h>
+#include <sys/disklabel.h>
+int get_block_device_size(int fd, unsigned long long* size)
+{
+  struct disklabel lab;
+  int status = (ioctl(fd, DIOCGDINFO, &lab) >= 0);
+  *size = lab.d_secsize * lab.d_nsectors;
+  return status;
 }
 #endif
 

--- a/lib/portability.h
+++ b/lib/portability.h
@@ -133,7 +133,7 @@ void *memmem(const void *haystack, size_t haystack_length,
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #include <sys/endian.h>
 
@@ -184,7 +184,7 @@ void *memmem(const void *haystack, size_t haystack_length,
 
 #ifdef __APPLE__
 #include <util.h>
-#elif !defined(__FreeBSD__)
+#elif !defined(__FreeBSD__) && !defined(__OpenBSD__)
 #include <pty.h>
 #else
 #include <termios.h>
@@ -208,13 +208,16 @@ ssize_t xattr_lset(const char*, const char*, const void*, size_t, int);
 ssize_t xattr_fset(int, const char*, const void*, size_t, int);
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 // macOS doesn't have these functions, but we can fake them.
 int mknodat(int, const char*, mode_t, dev_t);
 int posix_fallocate(int, off_t, off_t);
 
 // macOS keeps newlocale(3) in the non-POSIX <xlocale.h> rather than <locale.h>.
 #include <xlocale.h>
+#endif
+
+#if defined(__APPLE__) || defined(__OpenBSD__)
 static inline long statfs_bsize(struct statfs *sf) { return sf->f_iosize; }
 static inline long statfs_frsize(struct statfs *sf) { return sf->f_bsize; }
 #else


### PR DESCRIPTION
Adds OpenBSD support. `chrt` and `fallocate` don't build due to missing functions.