### PR TITLE
Minor readability changes to time.

### DIFF
--- a/toys/posix/time.c
+++ b/toys/posix/time.c
@@ -51,7 +51,7 @@ void time_main(void)
       "Voluntary context switches: %ld\nInvoluntary context switches: %ld\n",
       r, s, u, ru.ru_maxrss, ru.ru_majflt, ru.ru_minflt, ru.ru_inblock,
       ru.ru_oublock, ru.ru_nvcsw, ru.ru_nivcsw);
-    else fprintf(stderr, "real %f\nuser %f\nsys %f\n", r, u, s);
+    else fprintf(stderr, "\nreal\t%f\nuser\t%f\nsys\t%f\n", r, u, s);
     toys.exitval = WIFEXITED(stat) ? WEXITSTATUS(stat) : WTERMSIG(stat);
   }
 }


### PR DESCRIPTION
Specifically, a newline was added, and tabs were used instead of spaces.
If you're curious, here's the original output of `time`, with the result of the sample input  `echo "Hello."` included:

```sh
Hello.
real 0.034699
user 0.000000
sys 0.000000
```
And here's the current output:
```sh
Hello.

real    0.030935
user    0.000000
sys     0.015625
```
That's it.