### PR TITLE
Fix various UndefinedBehaviorSanitizer warnings

### DIFF
--- a/main.c
+++ b/main.c
@@ -143,7 +143,9 @@ void toy_init(struct toy_list *which, char *argv[])
 
   // Free old toys contents (to be reentrant), but leave rebound if any
   // don't blank old optargs if our new argc lives in the old optargs.
-  if (argv<toys.optargs || argv>toys.optargs+toys.optc) free(toys.optargs);
+  if (toys.optargs) {
+    if (argv<toys.optargs || argv>toys.optargs+toys.optc) free(toys.optargs);
+  }
   memset(&toys, 0, offsetof(struct toy_context, rebound));
   if (oldwhich) memset(&this, 0, sizeof(this));
 

--- a/toys/lsb/seq.c
+++ b/toys/lsb/seq.c
@@ -47,7 +47,10 @@ static double parsef(char *s)
 {
   char *dp = strchr(s, '.');
 
-  if (dp++) TT.precision = maxof(TT.precision, strcspn(dp, "eE"));
+  if (dp) {
+      dp++;
+      TT.precision = maxof(TT.precision, strcspn(dp, "eE"));
+  }
 
   return xstrtod(s);
 }

--- a/toys/other/blkid.c
+++ b/toys/other/blkid.c
@@ -106,6 +106,10 @@ static void do_blkid(int fd, char *name)
         pass++;
         continue;
       }
+      if (fstypes[i].magic_len+fstypes[i].magic_offset-off > sizeof(toybuf)) {
+        pass++;
+        continue;
+      }
       if (fstypes[i].magic_offset < off) continue;
 
       // Populate 64 bit little endian magic value
@@ -141,7 +145,7 @@ static void do_blkid(int fd, char *name)
 
   len = fstypes[i].label_len;
   if (!FLAG(U) && len) {
-    s = toybuf+fstypes[i].label_off-off;
+    s = toybuf+(fstypes[i].label_off-off);
     if (!strcmp(type, "vfat")) {
       show_tag("SEC_TYPE", "msdos");
       while (len && s[len-1]==' ') len--;

--- a/toys/other/bzcat.c
+++ b/toys/other/bzcat.c
@@ -126,7 +126,7 @@ static unsigned int get_bits(struct bunzip_data *bd, char bits_wanted)
 
     // Avoid 32-bit overflow (dump bit buffer to top of output)
     if (bd->inbufBitCount>=24) {
-      bits = bd->inbufBits&((1<<bd->inbufBitCount)-1);
+      bits = bd->inbufBits&((1u<<bd->inbufBitCount)-1);
       bits_wanted -= bd->inbufBitCount;
       bits <<= bits_wanted;
       bd->inbufBitCount = 0;

--- a/toys/posix/ls.c
+++ b/toys/posix/ls.c
@@ -315,7 +315,7 @@ static void listfiles(int dirfd, struct dirtree *indir)
   if (!FLAG(f)) {
     unsigned long long blocks = 0;
 
-    qsort(sort, dtlen, sizeof(void *), (void *)compare);
+    if (dtlen > 0) qsort(sort, dtlen, sizeof(void *), (void *)compare);
     for (ul = 0; ul<dtlen; ul++) {
       entrylen(sort[ul], len);
       for (width = 0; width<8; width++)


### PR DESCRIPTION
This fixes all warnings encountered when running the tests, except for two errors in `toys/lsb/seq.c` that I'm not sure how to fix properly.

The first commit is taken from libxmp/libxmp@a2f88d0.
