### PR TITLE
Enable copy_file_range when it is available.

### DIFF
--- a/scripts/genconfig.sh
+++ b/scripts/genconfig.sh
@@ -104,7 +104,7 @@ EOF
   probesymbol TOYBOX_COPYFILERANGE << EOF
     #include <sys/syscall.h>
     #include <unistd.h>
-    int main(void) { copyfilerange(0, 0, 1, 0, 123, 0); }
+    int main(void) { syscall(__NR_copy_file_range, 0, 0, 1, 0, 123, 0); }
 EOF
   probesymbol TOYBOX_HASTIMERS << EOF
     #include <signal.h>


### PR DESCRIPTION
Changes:
1. fix the mistake in scripts/genconfig.sh;
2. `syscall(__NR_copy_file_range ...)` is more suitable, as there is not a `copy_file_range` in bionic.
3. Even compiled with glibc, toybox cannot use [copy_file_range](https://man7.org/linux/man-pages/man2/copy_file_range.2.html) easily, as we must define _GNU_SOURCE before include unistd.h first time.

Test:
1. dd if=/dev/urandom of=src.bin bs=4M count=1000
2. ln -s toyobox cp
5. ./cp src.bin dst.bin
6. sha256sum src.bin dst.bin