### PR TITLE
Handle diffing FIFOs.

### DIFF
--- a/tests/diff.test
+++ b/tests/diff.test
@@ -42,3 +42,16 @@ testing "--strip-trailing-cr on" "diff -u --strip-trailing-cr a b" "" "" ""
 echo -e "1\n2" > aa
 echo -e "1\n3" > bb
 testing "line format" "diff --unchanged-line-format=U%l --old-line-format=D%l --new-line-format=A%l aa bb" "U1D2A3" "" ""
+
+mkfifo fifo1
+mkfifo fifo2
+echo -e "1\n2" > fifo1&
+echo -e "1\n3" > fifo2&
+expected='--- fifo1
++++ fifo2
+@@ -1,2 +1,2 @@
+ 1
+-2
++3
+'
+testing "fifos" "diff -L fifo1 -L fifo2 fifo1 fifo2" "$expected" "" ""

--- a/tests/diff.test
+++ b/tests/diff.test
@@ -42,6 +42,7 @@ testing "--strip-trailing-cr on" "diff -u --strip-trailing-cr a b" "" "" ""
 echo -e "1\n2" > aa
 echo -e "1\n3" > bb
 testing "line format" "diff --unchanged-line-format=U%l --old-line-format=D%l --new-line-format=A%l aa bb" "U1D2A3" "" ""
+testing "line format empty" "diff --unchanged-line-format= --old-line-format=D%l --new-line-format=A%l aa bb" "D2A3" "" ""
 
 mkfifo fifo1
 mkfifo fifo2

--- a/toys/pending/diff.c
+++ b/toys/pending/diff.c
@@ -5,7 +5,7 @@
  *
  * See: http://cm.bell-labs.com/cm/cs/cstr/41.pdf
 
-USE_DIFF(NEWTOY(diff, "<2>2(unchanged-line-format):(old-line-format):(new-line-format):(color)(strip-trailing-cr)B(ignore-blank-lines)d(minimal)b(ignore-space-change)ut(expand-tabs)w(ignore-all-space)i(ignore-case)T(initial-tab)s(report-identical-files)q(brief)a(text)L(label)*S(starting-file):N(new-file)r(recursive)U(unified)#<0=3", TOYFLAG_USR|TOYFLAG_BIN|TOYFLAG_ARGFAIL(2)))
+USE_DIFF(NEWTOY(diff, "<2>2(unchanged-line-format):;(old-line-format):;(new-line-format):;(color)(strip-trailing-cr)B(ignore-blank-lines)d(minimal)b(ignore-space-change)ut(expand-tabs)w(ignore-all-space)i(ignore-case)T(initial-tab)s(report-identical-files)q(brief)a(text)L(label)*S(starting-file):N(new-file)r(recursive)U(unified)#<0=3", TOYFLAG_USR|TOYFLAG_BIN|TOYFLAG_ARGFAIL(2)))
 
 config DIFF
   bool "diff"


### PR DESCRIPTION
Also exit immediately if a seek fails.

In addition to the supplied test, also tested manually with:

./toybox diff <(echo -e "1\n2") <(echo -e "1\n3")

However, the "testing" function in runtest.sh doesn't handle such
syntax.