### PR TITLE
Use extglob rather than regex match operator.

### DIFF
--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -234,7 +234,7 @@ txpect()
         then
           [ -z "$A" -o "$X" -ne 0 ] && { do_fail;break;}
         else
-          if [ ${1::1} == 'R' ] && [[ "$A" =~ "${1:2}" ]]; then true
+          if [ ${1::1} == 'R' ] && [[ "$A" = *"${1:2}"* ]]; then true
           elif [ ${1::1} != 'R' ] && [ "$A" == "${1:1}" ]; then true
           else
             # Append the rest of the output if there is any.


### PR DESCRIPTION
Not all shells support =~. Android, for example, uses mksh, which does
not.

Change is from suggestion at http://www.mirbsd.org/mksh-faq.htm#regex-comparison