### PR TITLE
Use $(id -u) instead of $UID to detect root.

### DIFF
--- a/tests/test.test
+++ b/tests/test.test
@@ -48,7 +48,7 @@ MASK=111
 for i in x w r k g u; do
   [ $i == k ] && MASK=1000
   XX=no
-  [ $UID -eq 0 ] && [ $i == r -o $i == w ] && XX=yes  # Root always has access
+  [ $(id -u) -eq 0 ] && [ $i == r -o $i == w ] && XX=yes  # Root always has access
   # test everything off produces "off"
   chmod 000 walrus
   testcmd "-$i 0" "-$i walrus && echo yes || echo no" "$XX\n" "" ""
@@ -65,7 +65,7 @@ for i in uu+s gg+s k+t; do
 done
 # test each ugo+rwx bit position individually
 XX=no
-[ $UID -eq 0 ] && XX=yes  # Root always has access
+[ $(id -u) -eq 0 ] && XX=yes  # Root always has access
 for i in 1 10 100; do for j in x w r; do
   chmod $i walrus
 


### PR DESCRIPTION
We can't depend on a value being set for $UID.