### PR TITLE
portability: Fix timer_settime_wrap for 32bit systems with 64bit time_t

### DIFF
--- a/lib/portability.c
+++ b/lib/portability.c
@@ -711,6 +711,12 @@ int timer_create_wrap(clockid_t c, struct sigevent *se, timer_t *t)
   return 0;
 }
 
+#if !defined(SYS_timer_settime) && defined(SYS_timer_settime64)
+// glibc does not define defines SYS_timer_settime on 32-bit systems
+// with 64-bit time_t defaults e.g. riscv32
+#define SYS_timer_settime SYS_timer_settime64
+#endif
+
 int timer_settime_wrap(timer_t t, int flags, struct itimerspec *val,
   struct itimerspec *old)
 {


### PR DESCRIPTION
glibc does not define SYS_timer_settime if the 32bit syscall is not available, new architectures like riscv32 has defaulted to 64bit time_t from get go and avoided wiring 32bit syscall, therefore alias it to 64bit version here

Signed-off-by: Khem Raj <raj.khem@gmail.com>