### PR TITLE
fmt: Define GLOBALS 'width' as long, not int

### DIFF
--- a/toys/other/fmt.c
+++ b/toys/other/fmt.c
@@ -27,7 +27,7 @@ config FMT
 #include "toys.h"
 
 GLOBALS(
-  int width;
+  long width;
 
   int level, pos;
 )


### PR DESCRIPTION
This change fixes fmt toy for Linux/s390x.
Without that change width value is always 0 on that arch.

PS:
'make tests' pass after that change on Debian/s390 for defconfig.
All other Debian archs pass tests even without this fix.