### PR TITLE
toys/lsb/mount: make "mount -a" can mount directory bind in /etc/fstab

### DIFF
--- a/toys/lsb/mount.c
+++ b/toys/lsb/mount.c
@@ -178,7 +178,7 @@ static void mount_filesystem(char *dev, char *dir, char *type,
   if (type && !strcmp(type, "auto")) type = 0;
   if (flags & MS_MOVE) {
     if (type) error_exit("--move with -t");
-  } else if (!type) {
+  } else if (!type || !strcmp(type, "none")) {
     struct stat stdev, stdir;
 
     // file on file or dir on dir is a --bind mount.


### PR DESCRIPTION
Example:

/data/opt /opt none defaults,bind 0 0

Because of the "type" is "none", "if (!type)" will get false. And the directory mount as a devices.
```
mount("/data/opt", "/opt", "none", MS_REC|MS_SILENT, NULL) = -1 ENODEV (No such device)
write(2, "mount: ", 7mount: )                  = 7
write(2, "'/data/opt'->'/opt'", 19'/data/opt'->'/opt')     = 19
write(2, ": No such device", 16: No such device)        = 16
write(2, "\n", 1
```

By adding another judgment: "if(!type || !strcmp(type, "none"))". it solved the problem.
```
getuid()                                = 0
stat("/data/opt", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/opt", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
mount("/data/opt", "/opt", 0x561bbefd67c8, MS_BIND|MS_SILENT, NULL) = 0
```
Logs only show in comment.
Signed-off-by: shiptux <shiptux@gmail.com>