### PR TITLE
rename itoa to toybox_itoa in seq.c, to avoid clashes

### DIFF
--- a/toys/lsb/seq.c
+++ b/toys/lsb/seq.c
@@ -54,7 +54,7 @@ static double parsef(char *s)
 
 // fast integer conversion to decimal string
 // TODO move to lib?
-static char *itoa(char *s, int i)
+static char *toybox_itoa(char *s, int i)
 {
   char buf[16], *ff = buf;
   unsigned n = i;
@@ -112,9 +112,9 @@ void seq_main(void)
     inc = increment;
     ss = toybuf;
     if (inc>0) for (; ii<=len; ii += inc)
-      ss = flush_toybuf(itoa(ss, ii));
+      ss = flush_toybuf(toybox_itoa(ss, ii));
     else if (inc<0) for (; ii>=len; ii += inc)
-      ss = flush_toybuf(itoa(ss, ii));
+      ss = flush_toybuf(toybox_itoa(ss, ii));
     if (ss != toybuf) xwrite(1, toybuf, ss-toybuf);
 
     return;


### PR DESCRIPTION
As title, this is to avoid clashing with systems where `itoa` is already defined. If the name is not satisfactory then just let me know of a more appropriate one.