### PR TITLE
change xrunread parameter name to to_stdin, matching xwrap.c

### DIFF
--- a/lib/lib.h
+++ b/lib/lib.h
@@ -130,7 +130,7 @@ int xpclose_both(pid_t pid, int *pipes);
 pid_t xpopen(char **argv, int *pipe, int isstdout);
 pid_t xpclose(pid_t pid, int pipe);
 int xrun(char **argv);
-char *xrunread(char *argv[], char *stdin);
+char *xrunread(char *argv[], char *to_stdin);
 int xpspawn(char **argv, int*pipes);
 void xaccess(char *path, int flags);
 void xunlink(char *path);


### PR DESCRIPTION
As title, it looks like the first part of this was done in https://github.com/landley/toybox/commit/3dae8ebfe590a1b3ae86d2dc9d3e206357fd2eba, this is just to complete the change. 