### PR TITLE
Fix GLOBALS() for nsenter

### DIFF
--- a/toys/other/nsenter.c
+++ b/toys/other/nsenter.c
@@ -77,7 +77,7 @@ config NSENTER
 #define setns(fd, nstype) syscall(SYS_setns, fd, nstype)
 
 GLOBALS(
-  char *UupnmiC[6];
+  char *UupnmiC[7];
   long t;
 )
 


### PR DESCRIPTION
When -C was added in d0c52934a39a5795af12bbf904a093306e38981e, the number for the arguments were not modified.

-t argument is not set correctly.

Change-Id: I17f448c5d29b1cafb1a1e5226025eaa96cdbb92d