### PR TITLE
addresses in sed are in base 10

### DIFF
--- a/toys/posix/sed.c
+++ b/toys/posix/sed.c
@@ -826,8 +826,8 @@ static void parse_pattern(char **pline, long len)
 
       if (i && *line == '+' && isdigit(line[1])) {
         line++;
-        command->lmatch[i] = -2-strtol(line, &line, 0);
-      } else if (isdigit(*line)) command->lmatch[i] = strtol(line, &line, 0);
+        command->lmatch[i] = -2-strtol(line, &line, 10);
+      } else if (isdigit(*line)) command->lmatch[i] = strtol(line, &line, 10);
       else if (*line == '$') {
         command->lmatch[i] = -1;
         line++;


### PR DESCRIPTION
posix requires base 10 numbers, so 010 should equal 10 and not 8