### PR TITLE
Fix stty not setting baud rate to 57600

### DIFF
--- a/toys/pending/stty.c
+++ b/toys/pending/stty.c
@@ -65,7 +65,7 @@ static speed_t speed(int baud)
 
   for (i=0;i<ARRAY_LEN(bauds);i++) if (bauds[i] == baud) break;
   if (i == ARRAY_LEN(bauds)) error_exit("unknown speed: %d", baud);
-  return i+4081*(i>16);
+  return i+4081*(i>=16);
 }
 
 struct flag {


### PR DESCRIPTION
When attempting to set the baud rate to 57600 using stty, the command is ignored. This is because baud rates of 57600 and higher require a special flag (CBAUDEX) to indicate extended baud rates.