### PR TITLE
Fix tests for getfattr/setfattr

### DIFF
--- a/tests/getfattr.test
+++ b/tests/getfattr.test
@@ -4,14 +4,23 @@
 
 #testing "name" "command" "result" "infile" "stdin"
 
+function clean()
+{
+  # The filesystem may include some extended attributes by default (for
+  # instance, security.selinux). Skip them.
+  grep -v "security\."
+}
+
 mkdir attrs
 touch attrs/file
 setfattr -n user.empty attrs/file
 setfattr -n user.data -v hello attrs/file
+setfattr -n user.more -v world attrs/file
 
-# The filesystem may include some extended attributes by default (for
-# instance, security.selinux). Use the -n option to limit the output.
-
+testing "" "getfattr attrs/file | clean" \
+    "# file: attrs/file\nuser.data\nuser.empty\nuser.more\n\n" "" ""
+testing "-d" "getfattr -d attrs/file | clean" \
+    "# file: attrs/file\nuser.data=\"hello\"\nuser.empty\nuser.more=\"world\"\n\n" "" ""
 testing "-n" "getfattr -n user.empty attrs/file" \
     "# file: attrs/file\nuser.empty\n\n" "" ""
 testing "-d -n" "getfattr -d -n user.data attrs/file" \

--- a/tests/setfattr.test
+++ b/tests/setfattr.test
@@ -4,21 +4,25 @@
 
 #testing "name" "command" "result" "infile" "stdin"
 
+function clean()
+{
+  # The filesystem may include some extended attributes by default (for
+  # instance, security.selinux). Skip them.
+  grep -v "security\."
+}
+
 mkdir attrs
 touch attrs/file
 setfattr -n user.empty attrs/file
 setfattr -n user.data -v hello attrs/file
 setfattr -n user.delete-me -v hello attrs/file
 
-# The filesystem may include some extended attributes by default (for
-# instance, security.selinux). Use the -n option to limit the output.
-
 testing "-x" \
-    "setfattr -x user.delete-me attrs/file && getfattr -n user.delete-me attrs/file" \
-    "# file: attrs/file\n\n" "" ""
-testing "-n" "setfattr -n user.new attrs/file && getfattr -n user.new -d attrs/file" \
-    "# file: attrs/file\nuser.new\n\n" "" ""
-testing "-n -v" "setfattr -n user.new -v data attrs/file && getfattr -n user.new -d attrs/file" \
-    "# file: attrs/file\nuser.new=\"data\"\n\n" "" ""
+    "setfattr -x user.delete-me attrs/file && getfattr attrs/file | clean" \
+    "# file: attrs/file\nuser.data\nuser.empty\n\n" "" ""
+testing "-n" "setfattr -n user.new attrs/file && getfattr -d attrs/file | clean" \
+    "# file: attrs/file\nuser.data=\"hello\"\nuser.empty\nuser.new\n\n" "" ""
+testing "-n -v" "setfattr -n user.new -v data attrs/file && getfattr -d attrs/file | clean" \
+    "# file: attrs/file\nuser.data=\"hello\"\nuser.empty\nuser.new=\"data\"\n\n" "" ""
 
 rm -rf attrs


### PR DESCRIPTION
The test system may have extended attributes set by default (for instance, security.selinux on Android). Support these by only testing part of the output.

This is similar to tests/chattr.test which filters the output. 