### PR TITLE
hexdump: fix NUL character handling

### DIFF
--- a/toys/pending/hexdump.c
+++ b/toys/pending/hexdump.c
@@ -102,7 +102,7 @@ void do_hexdump(int fd, char *name)
     continue;
 
 newline:
-    strncpy(TT.linebuf+(TT.bc%16), toybuf, TT.len);
+    memcpy(TT.linebuf+(TT.bc%16), toybuf, TT.len);
     TT.bc = TT.bc % 16 + TT.len;
     sl = 0;
     if (TT.pos + TT.bc == TT.s+TT.n || TT.fn == toys.optc || TT.bc == 16) {


### PR DESCRIPTION
When dumping a file containing some NUL characters, the display is wrong because all remaining characters on the line are replaced by NUL. This error comes from the fact that the copy of the read buffer into the line buffer is done using strncpy() which handles NUL character as end of string and pads the destination buffer with NUL afterwards.

To avoid data manipulation during buffer copy, simply replace strncpy() with its memory equivalent memcpy() that does not interpret the read data.