### PR TITLE
Fix ls -h total size bug

### DIFF
--- a/toys/posix/ls.c
+++ b/toys/posix/ls.c
@@ -130,9 +130,12 @@ static int numlen(long long ll)
 
 static int print_with_h(char *s, long long value, int blocks)
 {
+  if (FLAG(h)) {
+    if (blocks) value *= 1024;
+    return human_readable(s, value, 0);
+  }
   if (blocks) value = (value * 1024) / TT.block_size;
-  if (FLAG(h)) return human_readable(s, value, 0);
-  else return sprintf(s, "%lld", value);
+  return sprintf(s, "%lld", value);
 }
 
 // Figure out size of printable entry fields for display indent/wrap


### PR DESCRIPTION
Hi,

I found a bug: While using ls -h, total size of folder shows wrong value.
==========
environment:
$ ls -l
total 2097156
-rw-rw-r-- 1 benchang benchang 2147483648  七  17 18:09 2G_file

before:
$ ../toybox/toybox ls -h
total 2.0M
2G_file

after:
$ ../toybox/toybox ls -h
total 2.0G
2G_filels 
==========

I have done several tests, and it looks correct and like there are no other side effects.
E.g.:
ls -h
ls -l
ls -s
ls -ls
ls -lh
ls -hs
ls -lhs
ls -h --block-size=1024
ls -l --block-size=1024
ls -s --block-size=1024
ls -ls --block-size=1024
ls -lh --block-size=1024
ls -hs --block-size=1024
ls -lhs --block-size=1024
ls -h --block-size=4096
ls -l --block-size=4096
ls -s --block-size=4096
ls -ls --block-size=4096
ls -lh --block-size=4096
ls -hs --block-size=4096
ls -lhs --block-size=4096






