### PR TITLE
Use POSIX-compliant `od -A` argument value

### DIFF
--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -236,7 +236,7 @@ if grep -qx 'CONFIG_TOYBOX_ZHELP=y' "$KCONFIG_CONFIG"
 then
   do_loudly $HOSTCC -I . scripts/install.c -o "$UNSTRIPPED"/instlist || exit 1
   { echo "#define ZHELP_LEN $("$UNSTRIPPED"/instlist --help | wc -c)" &&
-    "$UNSTRIPPED"/instlist --help | gzip -9 | od -Anone -vtx1 | \
+    "$UNSTRIPPED"/instlist --help | gzip -9 | od -An -vtx1 | \
     sed 's/ /,0x/g;1s/^,/static char zhelp_data[] = {\n /;$s/.*/&};/'
   } > "$GENDIR"/zhelp.h || exit 1
 else


### PR DESCRIPTION
POSIX only specifies the characters 'd', 'o', 'x', and 'n' as valid `od -A` argument values. [1] Pedantic implementations of `od` may expect the argument value to be a single character instead of ignoring these extra characters. [2]

[1] https://pubs.opengroup.org/onlinepubs/9799919799/utilities/od.html
[2] https://github.com/uutils/coreutils/pull/6674