### PR TITLE
getty: fixed double backslash not being printed

### DIFF
--- a/toys/pending/getty.c
+++ b/toys/pending/getty.c
@@ -149,6 +149,7 @@ void print_issue(void)
       else if (ch == 'r') xputsn(TT.uts.release);
       else if (ch == 's') xputsn(TT.uts.sysname);
       else if (ch == 'l') xputsn(TT.tty_name);
+      else if (ch == '\\') xputc(ch);
       else printf("<bad escape>");
     } else xputc(ch);
   }


### PR DESCRIPTION
Hi, getty was not working correctly with escaped backslashes `\\` by treating them as bad escape. This commit fixed this behaviour.


PS.: Please update the MX record of lists.landley.net, since it is lacking. So I couldn't use your mailing list.

Thanks!