### PR TITLE
www/news.html: Fix typo in 0.8.3 release post

### DIFF
--- a/www/news.html
+++ b/www/news.html
@@ -1825,7 +1825,7 @@ Jarno Mäkipää fixed utf8 support in cut -C, and cp --parents.
 David Legault complained that dir/.* tells rm to delete dir/.. and we'd do it.
 JakeSFR pointed out a bug in file's identification of broken symlinks.
 William Haddon fixed cp to treat a directory with a trailing slash
-teh same as one without.
+the same as one without.
 Denys Nykula fixed rm -i not to prompt for an empty "" argument.
 SebiderSushi reported that chmod g+s wasn't working.
 The linux kernel doesn't let an O_PATH fd work with fgetxattr(), so


### PR DESCRIPTION
I fixed a small typo in the 0.8.3 release post.