### PR TITLE
Remove unwanted perror_msg() when using tar --selinux

### DIFF
--- a/toys/posix/tar.c
+++ b/toys/posix/tar.c
@@ -406,7 +406,6 @@ static int add_to_tar(struct dirtree *node)
           strcpy(buf+start+sz, "\n");
           write_prefix_block(buf, start+sz+2, 'x');
         } else if (errno==ENODATA || errno==ENOTSUP) len = 0;
-        if (len) perror_msg("getfilecon %s", name);
 
         free(buf);
         break;


### PR DESCRIPTION
Doesn't seem to do anything useful and even seems to crash on my system.