### PR TITLE
Fix ftpget exit with error code 1

### DIFF
--- a/toys/net/ftpget.c
+++ b/toys/net/ftpget.c
@@ -176,6 +176,8 @@ void ftpget_main(void)
       } else lenl = 0;
 
       ftp_line(cmd, remote, -1);
+      if (FLAG(g))
+        ftp_line(0, 0, 150);
       lenl += xsendfile(port, ii);
       ftp_line(0, 0, FLAG(g) ? 226 : 150);
     } else if (FLAG(s)) {


### PR DESCRIPTION
The ftpget needs to receive a 150 status code from the server before proceeding to receive actual data, followed by a 226 status code before sending the QUIT command. The implementation in BusyBox 1.35.0 (networking/ftpgetput.c, lines 183 and 233) follows this logic, allowing it to successfully send QUIT and exit without errors.

With this patch applied, the error message like:
"150 Opening BINARY mode data connection for test.txt (10 bytes)" will no longer be misinterpreted as an error. The program can then exit with code 0 instead of 1.