### PR TITLE
Fix ftpget tool exit with error code 1

### DIFF
--- a/toys/net/ftpget.c
+++ b/toys/net/ftpget.c
@@ -176,6 +176,8 @@ void ftpget_main(void)
       } else lenl = 0;
 
       ftp_line(cmd, remote, -1);
+      if (FLAG(g))
+        ftp_line(0, 0, 150);
       lenl += xsendfile(port, ii);
       ftp_line(0, 0, FLAG(g) ? 226 : 150);
     } else if (FLAG(s)) {


### PR DESCRIPTION
Hi landley,

ftpget tool use with get command like: "ftpget 192.168.0.123 /data/test.txt test.txt" will exit with error code 1 instead of 0.
I check the code flow in "ftp_line" function, it will enter "error_exit_raw" because "rc != must (must==226)".

The ftpget needs to receive a 150 status code from the server before proceeding to receive actual data, then followed by get 226 status code before sending the "QUIT" command.
The implementation in BusyBox 1.35.0 (networking/ftpgetput.c, lines 233(ftp_receive) and 183(pump_data_and_QUIT)) follows this logic, allowing it to successfully send "QUIT" and exit without errors.

With this patch applied, the message like: "150 Opening BINARY mode data connection for test.txt (10 bytes)" will no longer be misinterpreted as an error. The program can then exit with code 0 instead of 1.