### PR TITLE
xsendfile_len() to exit with error if underlying write fails

### DIFF
--- a/lib/xwrap.c
+++ b/lib/xwrap.c
@@ -867,9 +867,9 @@ long long xsendfile_len(int in, int out, long long bytes)
 {
   long long len = sendfile_len(in, out, bytes, 0);
 
-  if (bytes != -1 && bytes != len) {
+  if (len == -1 || (bytes != -1 && bytes != len)) {
     if (out == 1 && len<0) xexit();
-    error_exit("short %s", (len<0) ? "write" : "read");
+    perror_exit("short %s", (len<0) ? "write" : "read");
   }
 
   return len;


### PR DESCRIPTION
`cp` currently will exit with success even if the underlying write syscall fails with an error. Fixing the issue I raised here: https://github.com/landley/toybox/issues/563

Currently `xsendfile_len()` calls `sendfile_len()` as part of copying files.
https://github.com/landley/toybox/blob/a3e5f1b1eaf2374d6894542c845887eb7db798bd/lib/xwrap.c#L865-L868

`sendfile_len()` can send `-1` when write fails. 
https://github.com/landley/toybox/blob/a3e5f1b1eaf2374d6894542c845887eb7db798bd/lib/portability.c#L649
https://github.com/landley/toybox/blob/a3e5f1b1eaf2374d6894542c845887eb7db798bd/lib/portability.c#L675

Nothing in `sendfile_len()` handles the case when `len=-1` is returned. Added that handling.

## Testing
Asking for reviewers to suggest how to add a test case where I can make `cp` fail to test that it is exiting with error. Local testing on my device, I see the expected behavior now.

Earlier, `cp` would exit with 0 even on write error:
```
strace cp file /folder/
...
write(4, "n\r\261\314l\266\361\257\370\335\213T\321\257\370t!\243\343a0\204\202\33={l,\v>+w"..., 4096) = -1 ENOSPC (No space left on device)
close(3)                                = 0
close(4)                                = 0
madvise(0x7769610000, 28672, MADV_DONTNEED) = 0
exit_group(0)                           = ?
+++ exited with 0 +++
```

Now, `cp` exits wit h failure:
```
# cp file /folder/                                                                
cp: short write: No space left on device
# echo $?                                                                                                    
1
```
```
# strace cp file /folder
write(4, "\227\33|\214\n\212\3357\314\371\311\10ZL\177\312\215\2456\264\337\255,9\261\321\271\365\350\332\4`"..., 4096) = -1 ENOSPC (No space left on device)
write(2, "cp: ", 4cp: )                     = 4
write(2, "short write", 11short write)             = 11
write(2, ": No space left on device", 25: No space left on device) = 25
write(2, "\n", 1
)                       = 1
exit_group(1)                           = ?
+++ exited with 1 +++
```

`cp` continues to work normally on success:
```
# cp file.dat anotherfile
# echo $?
0
```