### PR TITLE
restricts permissions on the pipeline

### DIFF
--- a/.github/workflows/toybox.yml
+++ b/.github/workflows/toybox.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   MacOS-13:
     runs-on: macos-13


### PR DESCRIPTION
Hi! This PR restricts permissions on the pipeline, following [the best security practices](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information) recommended by GitHub.