### PR TITLE
switch_root: fix switch_root's interaction with mount namespaces

### DIFF
--- a/toys/other/switch_root.c
+++ b/toys/other/switch_root.c
@@ -97,6 +97,12 @@ void switch_root_main(void)
   // Ok, enough safety checks: wipe root partition.
   dirtree_read("/", del_node);
 
+  // Fix the appearance of the mount table in the newroot chroot
+  if (mount(".", "/", NULL, MS_MOVE, NULL)) {
+    perror_msg("mount");
+    goto panic;
+  }
+
   // Enter the new root before starting init
   if (chroot(".")) {
     perror_msg("chroot");


### PR DESCRIPTION
Commit c04b565204eb6b7e3508ac8dd42539ab97752635
reworked how switch_root moves mounts into the new root, but it inadvertently removed the moving of the root itself onto / for the mount namespace before chrooting.

This confuses future users of the mount namespaces since root mount gets preserved and thus entering any derived mount namespace retains the pre-chroot structure.

Found in yocto (scarthgap, toybox 0.8.11) where the mount namespaces contained just /rootfs in their /. Repro is simple:

Before:

```
% sudo nsenter -m -t $$
nsenter: failed to execute /bin/sh: No such file or directory
% sudo nsenter -m -t $$ /rootfs/usr/lib64/ld-linux-x86-64.so.2 \
    --library-path /rootfs/lib:/rootfs/lib64:/rootfs/usr/lib64:/rootfs/usr/lib \
   /rootfs/usr/sbin/chroot.coreutils /rootfs
#
```

After:
```
% sudo nsenter -m -t $$
#
```

Fixes #557