### PR TITLE
diff: Make flags with arguments non-collated

### DIFF
--- a/tests/diff.test
+++ b/tests/diff.test
@@ -44,6 +44,7 @@ testcmd "--strip-trailing-cr on" '-u --strip-trailing-cr a b; echo $?' \
 echo -e "1\n2" > aa
 echo -e "1\n3" > bb
 testcmd "line format" "--unchanged-line-format=U%l --old-line-format=D%l --new-line-format=A%l aa bb" "U1D2A3" "" ""
+testcmd "line format non-collated" "--unchanged-line-format U%l --old-line-format D%l --new-line-format A%l aa bb" "U1D2A3" "" ""
 testcmd "line format empty" "--unchanged-line-format= --old-line-format=D%l --new-line-format=A%l aa bb" "D2A3" "" ""
 
 ln -s aa cc
@@ -111,6 +112,25 @@ int baz() {
 }
 '> b
 testcmd 'show function' "--show-function-line=' {$' -U1 -L lll -L rrr a b" \
+'--- lll
++++ rrr
+@@ -1,2 +1,2 @@
+-int bar() {
++int barbar() {
+ }
+@@ -7,3 +7,3 @@ int foo() {
+ int baz() {
+-  1
++  1a
+   {2
+@@ -11,3 +11,3 @@ int baz() {
+   4
+-  foo
++  bar
+ }
+' \
+'' ''
+testcmd 'show function non-collated' "-F ' {$' -U1 -L lll -L rrr a b" \
 '--- lll
 +++ rrr
 @@ -1,2 +1,2 @@

--- a/toys/pending/diff.c
+++ b/toys/pending/diff.c
@@ -8,7 +8,7 @@
  *
  * Deviations from posix: always does -u
 
-USE_DIFF(NEWTOY(diff, "<2>2(unchanged-line-format):;(old-line-format):;(no-dereference);(new-line-format):;(color)(strip-trailing-cr)B(ignore-blank-lines)d(minimal)b(ignore-space-change)ut(expand-tabs)w(ignore-all-space)i(ignore-case)T(initial-tab)s(report-identical-files)q(brief)a(text)S(starting-file):F(show-function-line):;L(label)*N(new-file)r(recursive)U(unified)#<0=3", TOYFLAG_USR|TOYFLAG_BIN|TOYFLAG_ARGFAIL(2)))
+USE_DIFF(NEWTOY(diff, "<2>2(unchanged-line-format):(old-line-format):(no-dereference)(new-line-format):(color)(strip-trailing-cr)B(ignore-blank-lines)d(minimal)b(ignore-space-change)ut(expand-tabs)w(ignore-all-space)i(ignore-case)T(initial-tab)s(report-identical-files)q(brief)a(text)S(starting-file):F(show-function-line):L(label)*N(new-file)r(recursive)U(unified)#<0=3", TOYFLAG_USR|TOYFLAG_BIN|TOYFLAG_ARGFAIL(2)))
 
 config DIFF
   bool "diff"


### PR DESCRIPTION
They should be non-collated to match gnu diff's behavior of allowing a space between the flag and its argument.

Disclaimer: this cl was written by AI. (but manually tested by me)

Fixes #597