### PR TITLE
Always pass an access mode to open()/openat()

### DIFF
--- a/lib/dirtree.c
+++ b/lib/dirtree.c
@@ -126,7 +126,7 @@ static struct dirtree *dirtree_handle_callback(struct dirtree *new,
 
   if (S_ISDIR(new->st.st_mode) && (flags & df)) {
     // TODO: check openat returned fd for errors... and do what about it?
-    if (*new->name) fd = openat(dirtree_parentfd(new), new->name, O_CLOEXEC);
+    if (*new->name) fd = openat(dirtree_parentfd(new), new->name, O_RDONLY | O_CLOEXEC);
     if (flags&DIRTREE_BREADTH) {
       new->again |= DIRTREE_BREADTH;
       if ((DIRTREE_ABORT & dirtree_recurse(new, 0, fd, flags)) ||

--- a/toys/pending/getty.c
+++ b/toys/pending/getty.c
@@ -185,7 +185,7 @@ static void utmp_entry(void)
   int fd;
 
   // We're responsible for ensuring that the utmp file exists.
-  if (access(_PATH_UTMP, F_OK) && (fd = open(_PATH_UTMP, O_CREAT, 0664)) != -1)
+  if (access(_PATH_UTMP, F_OK) && (fd = open(_PATH_UTMP, O_RDONLY|O_CREAT, 0664)) != -1)
     close(fd);
 
   // Find any existing entry.

--- a/toys/pending/syslogd.c
+++ b/toys/pending/syslogd.c
@@ -269,7 +269,7 @@ static void open_logfiles(void)
     } else tfd->logfd = open(tfd->filename, O_CREAT | O_WRONLY | O_APPEND, 0666);
     if (tfd->logfd < 0) {
       tfd->filename = "/dev/console";
-      tfd->logfd = open(tfd->filename, O_APPEND);
+      tfd->logfd = open(tfd->filename, O_WRONLY | O_APPEND);
     }
   }
 }

--- a/toys/posix/cp.c
+++ b/toys/posix/cp.c
@@ -234,7 +234,7 @@ static int cp_node(struct dirtree *try)
         // that what we open _is_ a directory rather than something else.
 
         if (!mkdirat(cfd, catch, try->st.st_mode | 0200) || errno == EEXIST)
-          if (-1 != (try->extra = openat(cfd, catch, O_NOFOLLOW)))
+          if (-1 != (try->extra = openat(cfd, catch, O_RDONLY|O_NOFOLLOW)))
             if (!fstat(try->extra, &st2) && S_ISDIR(st2.st_mode))
               return DIRTREE_COMEAGAIN | DIRTREE_SYMFOLLOW*FLAG(L);
 

--- a/toys/posix/grep.c
+++ b/toys/posix/grep.c
@@ -484,7 +484,7 @@ static int do_grep_r(struct dirtree *new)
   if (new->parent && !FLAG(h)) toys.optflags |= FLAG_H;
 
   name = dirtree_path(new, 0);
-  do_grep(openat(dirtree_parentfd(new), new->name, O_NONBLOCK|O_NOCTTY), name);
+  do_grep(openat(dirtree_parentfd(new), new->name, O_RDONLY|O_NONBLOCK|O_NOCTTY), name);
   free(name);
 
   return 0;

--- a/toys/posix/ls.c
+++ b/toys/posix/ls.c
@@ -364,7 +364,7 @@ static void listfiles(int dirfd, struct dirtree *indir)
     // In this case only show dirname/total header when given -R.
     dt = indir->child;
     if (dt && S_ISDIR(dt->st.st_mode) && !dt->next && !(FLAG(d)||FLAG(R))) {
-      listfiles(open(dt->name, 0), TT.singledir = dt);
+      listfiles(open(dt->name, O_RDONLY), TT.singledir = dt);
 
       return;
     }
@@ -573,7 +573,7 @@ static void listfiles(int dirfd, struct dirtree *indir)
 
     // Recurse into dirs if at top of the tree or given -R
     if (!indir->parent || (FLAG(R) && dirtree_notdotdot(sort[ul])))
-      listfiles(openat(dirfd, sort[ul]->name, 0), sort[ul]);
+      listfiles(openat(dirfd, sort[ul]->name, O_RDONLY), sort[ul]);
     free((void *)sort[ul]->extra);
   }
   free(sort);

--- a/toys/posix/touch.c
+++ b/toys/posix/touch.c
@@ -72,7 +72,7 @@ void touch_main(void)
     } else {
       if (!utimensat(AT_FDCWD, s, ts, FLAG(h)*AT_SYMLINK_NOFOLLOW)) continue;
       if (FLAG(c)) continue;
-      if (access(s, F_OK) && (-1!=(fd = open(s, O_CREAT, 0666)))) {
+      if (access(s, F_OK) && (-1!=(fd = open(s, O_WRONLY | O_CREAT, 0666)))) {
         close(fd);
         if (toys.optflags) ss--;
         continue;


### PR DESCRIPTION
On Linux, O_RDONLY is 0, so it's used implicitly, but that's not true on
all platforms.  POSIX requires an access mode to be given explicitly.
