### PR TITLE
kconfig: Fix const qualifier warning in confdata.c

### DIFF
--- a/kconfig/confdata.c
+++ b/kconfig/confdata.c
@@ -410,7 +410,7 @@ int conf_write(const char *name)
 	dirname[0] = 0;
 	if (name && name[0]) {
 		struct stat st;
-		char *slash;
+		const char *slash;
 
 		if (!stat(name, &st) && S_ISDIR(st.st_mode)) {
 			strcpy(dirname, name);


### PR DESCRIPTION
Change the type of 'slash' variable from 'char*' to 'const char*' in conf_write() function. 
This fixes the compiler warning about discarding const qualifier when assigning the 
return value of strrchr(), which returns 'const char*'.

This change ensures const-correctness and prevents accidental 
modification of the string returned by strrchr().

Fixes warning:
  warning: assignment discards 'const' qualifier from pointer target
  type [-Wdiscarded-qualifiers]